### PR TITLE
PKG-211: Link LLVM statically

### DIFF
--- a/config/llvm.m4
+++ b/config/llvm.m4
@@ -47,20 +47,20 @@ AC_DEFUN([PGAC_LLVM_SUPPORT],
 
   # Collect compiler flags necessary to build the LLVM dependent
   # shared library.
-  for pgac_option in `$LLVM_CONFIG --cppflags`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --cppflags`; do
     case $pgac_option in
       -I*|-D*) LLVM_CPPFLAGS="$pgac_option $LLVM_CPPFLAGS";;
     esac
   done
 
-  for pgac_option in `$LLVM_CONFIG --ldflags`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --ldflags`; do
     case $pgac_option in
       -L*) LDFLAGS="$LDFLAGS $pgac_option";;
     esac
   done
 
   # ABI influencing options, standard influencing options
-  for pgac_option in `$LLVM_CONFIG --cxxflags`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --cxxflags`; do
     case $pgac_option in
       -fno-rtti*) LLVM_CXXFLAGS="$LLVM_CXXFLAGS $pgac_option";;
       -std=*) LLVM_CXXFLAGS="$LLVM_CXXFLAGS $pgac_option";;
@@ -71,7 +71,7 @@ AC_DEFUN([PGAC_LLVM_SUPPORT],
   # libs. As some components are optional, we can't just list all of
   # them as it'd raise an error.
   pgac_components='';
-  for pgac_component in `$LLVM_CONFIG --components`; do
+  for pgac_component in `$LLVM_CONFIG --link-static --components`; do
     case $pgac_component in
       engine) pgac_components="$pgac_components $pgac_component";;
       debuginfodwarf) pgac_components="$pgac_components $pgac_component";;
@@ -85,7 +85,7 @@ AC_DEFUN([PGAC_LLVM_SUPPORT],
   # And then get the libraries that need to be linked in for the
   # selected components.  They're large libraries, we only want to
   # link them into the LLVM using shared library.
-  for pgac_option in `$LLVM_CONFIG --libs --system-libs $pgac_components`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --libs --system-libs $pgac_components`; do
     case $pgac_option in
       -l*) LLVM_LIBS="$LLVM_LIBS $pgac_option";;
     esac

--- a/configure
+++ b/configure
@@ -5217,20 +5217,20 @@ fi
 
   # Collect compiler flags necessary to build the LLVM dependent
   # shared library.
-  for pgac_option in `$LLVM_CONFIG --cppflags`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --cppflags`; do
     case $pgac_option in
       -I*|-D*) LLVM_CPPFLAGS="$pgac_option $LLVM_CPPFLAGS";;
     esac
   done
 
-  for pgac_option in `$LLVM_CONFIG --ldflags`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --ldflags`; do
     case $pgac_option in
       -L*) LDFLAGS="$LDFLAGS $pgac_option";;
     esac
   done
 
   # ABI influencing options, standard influencing options
-  for pgac_option in `$LLVM_CONFIG --cxxflags`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --cxxflags`; do
     case $pgac_option in
       -fno-rtti*) LLVM_CXXFLAGS="$LLVM_CXXFLAGS $pgac_option";;
       -std=*) LLVM_CXXFLAGS="$LLVM_CXXFLAGS $pgac_option";;
@@ -5241,7 +5241,7 @@ fi
   # libs. As some components are optional, we can't just list all of
   # them as it'd raise an error.
   pgac_components='';
-  for pgac_component in `$LLVM_CONFIG --components`; do
+  for pgac_component in `$LLVM_CONFIG --link-static --components`; do
     case $pgac_component in
       engine) pgac_components="$pgac_components $pgac_component";;
       debuginfodwarf) pgac_components="$pgac_components $pgac_component";;
@@ -5255,7 +5255,7 @@ fi
   # And then get the libraries that need to be linked in for the
   # selected components.  They're large libraries, we only want to
   # link them into the LLVM using shared library.
-  for pgac_option in `$LLVM_CONFIG --libs --system-libs $pgac_components`; do
+  for pgac_option in `$LLVM_CONFIG --link-static --libs --system-libs $pgac_components`; do
     case $pgac_option in
       -l*) LLVM_LIBS="$LLVM_LIBS $pgac_option";;
     esac

--- a/meson.build
+++ b/meson.build
@@ -792,7 +792,7 @@ endif
 llvmopt = get_option('llvm')
 llvm = not_found_dep
 if add_languages('cpp', required: llvmopt, native: false)
-  llvm = dependency('llvm', version: '>=10', method: 'config-tool', required: llvmopt)
+  llvm = dependency('llvm', version: '>=10', method: 'config-tool', required: llvmopt, static: true)
 
   if llvm.found()
 


### PR DESCRIPTION
This commit modifies the build scripts so that `llvmjit.so` links LLVM statically instead of dynamically. No other binary affected, the change shouldn't be user visible at all.

The memory footprint of postgres is also unaffected: only the `llvmjit.so` dynamic library is affected. If postgres doesn't use JIT, the LLVM library isn't loaded, as before. If it uses JIT, it is loaded as part of `llvmjit.so`, sa before.

The only change is the binary size of `llvmjit.so`.

```
ldd lib/postgresql/llvmjit.so
	linux-vdso.so.1 (0x00007fff3fd2c000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fc6596bc000)
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x00007fc65968a000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fc65945e000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fc659377000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fc659357000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc65912c000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc65c078000)
```