### PR TITLE
PG-854: Global keyring support

### DIFF
--- a/.github/workflows/psp.yml
+++ b/.github/workflows/psp.yml
@@ -40,4 +40,5 @@ jobs:
           name: testlog-ubuntu-${{ matrix.ubuntu_version }}.04-meson-${{ matrix.build_type }}
           path: |
             src/build/testrun/
+            src/contrib/pg_tde/t/
           retention-days: 3

--- a/contrib/pg_tde/.vscode/settings.json
+++ b/contrib/pg_tde/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "tde_principal_key.h": "c"
+    }
+}

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -52,7 +52,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 
 		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
-			save_principal_key_info(mkey);
+			create_principal_key_info(mkey);
 		else
 			update_principal_key_info(mkey);
 

--- a/contrib/pg_tde/src/catalog/tde_global_space.c
+++ b/contrib/pg_tde/src/catalog/tde_global_space.c
@@ -181,11 +181,10 @@ create_principal_key(const char *key_name, GenericKeyring *keyring, Oid dbOid)
 
 	principalKey = palloc(sizeof(TDEPrincipalKey));
 	principalKey->keyInfo.databaseId = dbOid;
-	principalKey->keyInfo.keyId.version = DEFAULT_PRINCIPAL_KEY_VERSION;
-	principalKey->keyInfo.keyringId = keyring->key_id;
+	principalKey->keyInfo.keyringId = keyring->keyring_id;
 	strncpy(principalKey->keyInfo.keyId.name, key_name, TDE_KEY_NAME_LEN);
 	snprintf(principalKey->keyInfo.keyId.versioned_name, TDE_KEY_NAME_LEN,
-			 "%s_%d", principalKey->keyInfo.keyId.name, principalKey->keyInfo.keyId.version);
+			 "%s", principalKey->keyInfo.keyId.name);
 	gettimeofday(&principalKey->keyInfo.creationTime, NULL);
 
 	keyInfo = KeyringGenerateNewKeyAndStore(keyring, principalKey->keyInfo.keyId.versioned_name, INTERNAL_KEY_LEN, false);

--- a/contrib/pg_tde/src/include/catalog/keyring_min.h
+++ b/contrib/pg_tde/src/include/catalog/keyring_min.h
@@ -56,7 +56,7 @@ typedef enum KeyringReturnCodes
 typedef struct GenericKeyring
 {
     ProviderType type; /* Must be the first field */
-    Oid key_id;
+    int keyring_id;
     char provider_name[MAX_PROVIDER_NAME_LEN];
     char options[MAX_KEYRING_OPTION_LEN]; /* User provided options string*/
 } GenericKeyring;

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -25,7 +25,6 @@
 
 typedef struct TDEPrincipalKeyId
 {
-	uint32 version;
 	char name[PRINCIPAL_KEY_NAME_LEN];
 	char versioned_name[PRINCIPAL_KEY_NAME_LEN + 4];
 } TDEPrincipalKeyId;
@@ -66,13 +65,13 @@ extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, LWLockMode lockMode);
 extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, void *lockMode);
 #endif
 
-extern bool save_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);
+extern bool create_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);
 extern bool update_principal_key_info(TDEPrincipalKeyInfo *principal_key_info);
 
 extern Oid	GetPrincipalKeyProviderId(void);
-extern bool SetPrincipalKey(const char *key_name, const char *provider_name, bool ensure_new_key);
 extern bool AlterPrincipalKeyKeyring(const char *provider_name);
-extern bool RotatePrincipalKey(TDEPrincipalKey *current_key, const char *new_key_name, const char *new_provider_name, bool ensure_new_key);
 extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
+
+extern void PrincipalKeyGucInit(void);
 
 #endif /* PG_TDE_PRINCIPAL_KEY_H */

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -116,6 +116,8 @@ _PG_init(void)
 #ifdef PERCONA_EXT
 	XLogInitGUC();
 #endif
+	
+	PrincipalKeyGucInit();
 	prev_shmem_request_hook = shmem_request_hook;
 	shmem_request_hook = tde_shmem_request;
 	prev_shmem_startup_hook = shmem_startup_hook;

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -42,9 +42,20 @@ $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('PG_TDE_GLOBAL', 'file-2','/tmp/pg_tde_test_keyring_2g.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('PG_TDE_GLOBAL', 'file-3','/tmp/pg_tde_test_keyring_3.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap_basic;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -56,8 +67,8 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 #rotate key
-PGTDE::append_to_file("-- ROTATE KEY pg_tde_rotate_principal_key('rotated-principal-key','file-2');");
-$rt_value = $node->psql('postgres', "SELECT pg_tde_rotate_principal_key('rotated-principal-key','file-2');", extra_params => ['-a']);
+$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key1');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
@@ -66,12 +77,35 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+
+#Again rotate key
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 #Again rotate key
-PGTDE::append_to_file("-- ROTATE KEY pg_tde_rotate_principal_key();");
-$rt_value = $node->psql('postgres', "SELECT pg_tde_rotate_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key', 'PG_TDE_GLOBAL', 'file-3', false);", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
@@ -80,16 +114,73 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
+
+# TODO: add method to query current info
+# And maybe debug tools to show what's in a file keyring?
+
+#Again rotate key
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-keyX', 'PG_TDE_GLOBAL', 'file-2', false);", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Things still work after a restart
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+# But now can't be changed to another global provider
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-keyX2', 'PG_TDE_GLOBAL', 'file-2', false);", extra_params => ['-a']);
+PGTDE::append_to_file($stderr);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# end
 
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "DROP PGTDE EXTENSION");
+$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM RESET pg_tde.inherit_global_providers;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
+
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+# DROP EXTENSION
+($cmdret, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+PGTDE::append_to_file($stderr);
 # Stop the server
 $node->stop();
 

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -62,7 +62,7 @@ sub resp_url {
 }
  
 }
-my $pid = MyWebServer->new(8888)->background();
+my $pid = MyWebServer->new(8889)->background();
 
 
 # UPDATE postgresql.conf to include/load pg_tde library
@@ -78,7 +78,7 @@ my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION pg_td
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/url' ), to_json('secret'::text), NULL);", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);", extra_params => ['-a']);
 $rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','vault-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap_basic;', extra_params => ['-a']);
@@ -108,7 +108,7 @@ PGTDE::append_to_file($stdout);
 # Stop the server
 $node->stop();
 
-system("kill $pid");
+system("kill -9 $pid");
 
 # compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/007_access_control.pl
+++ b/contrib/pg_tde/t/007_access_control.pl
@@ -55,11 +55,6 @@ PGTDE::append_to_file("-- pg_tde_set_principal_key should also fail");
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a', '-U', 'test_access']);
 PGTDE::append_to_file($stderr);
 
-PGTDE::append_to_file("-- pg_tde_rotate_principal_key should give access denied error");
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_rotate_principal_key('rotated-principal-key','file-2');", extra_params => ['-a', '-U', 'test_access']);
-PGTDE::append_to_file($stderr);
-
-
 # now give key management access to test_access user
 PGTDE::append_to_file("-- grant key management access to test_access");
 $stdout = $node->safe_psql('postgres', "select pg_tde_grant_key_management_to_role('test_access');", extra_params => ['-a']);
@@ -76,10 +71,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a', '-U', 'test_access']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_rotate_principal_key('rotated-principal-key','file-2');", extra_params => ['-a', '-U', 'test_access']);
-PGTDE::append_to_file($stdout);
-
-$stdout = $node->safe_psql('postgres', "SELECT principal_key_name,key_provider_name,key_provider_id,principal_key_internal_name, principal_key_version from pg_tde_principal_key_info();", extra_params => ['-a', '-U', 'test_access']);
+$stdout = $node->safe_psql('postgres', "SELECT principal_key_name,key_provider_name,key_provider_id from pg_tde_principal_key_info();", extra_params => ['-a', '-U', 'test_access']);
 PGTDE::append_to_file($cmdret);
 
 
@@ -96,7 +88,7 @@ PGTDE::append_to_file("-- pg_tde_list_all_key_providers should also fail");
 PGTDE::append_to_file($stderr);
 
 PGTDE::append_to_file("-- pg_tde_principal_key_info should also fail");
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT principal_key_name,key_provider_name,key_provider_id,principal_key_internal_name, principal_key_version from pg_tde_principal_key_info();", extra_params => ['-a', '-U', 'test_access']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT principal_key_name,key_provider_name,key_provider_id from pg_tde_principal_key_info();", extra_params => ['-a', '-U', 'test_access']);
 PGTDE::append_to_file($stderr);
 
 

--- a/contrib/pg_tde/t/009_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/009_key_rotate_tablespace.pl
@@ -57,7 +57,7 @@ SELECT * FROM country_table;
 PGTDE::append_to_file($stdout);
 
 
-$cmdret = $node->psql('tbc', "SELECT pg_tde_rotate_principal_key('new-k', 'file-vault');", extra_params => ['-a']);
+$cmdret = $node->psql('tbc', "SELECT pg_tde_set_principal_key('new-k', 'file-vault');", extra_params => ['-a']);
 ok($cmdret == 0, "ROTATE KEY");
 PGTDE::append_to_file($stdout);
 

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -1,25 +1,88 @@
 CREATE EXTENSION pg_tde;
 -- server restart
+SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+1
+SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');
+2
+SELECT pg_tde_add_key_provider_file('PG_TDE_GLOBAL', 'file-2','/tmp/pg_tde_test_keyring_2g.per');
+-2
+SELECT pg_tde_add_key_provider_file('PG_TDE_GLOBAL', 'file-3','/tmp/pg_tde_test_keyring_3.per');
+-3
+SELECT pg_tde_list_all_key_providers();
+(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
+(2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
+SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+t
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap_basic;
 INSERT INTO test_enc (k) VALUES (5),(6);
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
--- ROTATE KEY pg_tde_rotate_principal_key('rotated-principal-key','file-2');
+0
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 -- server restart
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
+1|file-vault|rotated-principal-key1
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');
+-1|default_global_tablespace_keyring|tde-global-catalog-key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
--- ROTATE KEY pg_tde_rotate_principal_key();
+SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
+t
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 -- server restart
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
+2|file-2|rotated-principal-key2
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');
+-1|default_global_tablespace_keyring|tde-global-catalog-key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
+SELECT pg_tde_set_principal_key('rotated-principal-key', 'PG_TDE_GLOBAL', 'file-3', false);
+t
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- server restart
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
+-3|file-3|rotated-principal-key
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');
+-1|default_global_tablespace_keyring|tde-global-catalog-key
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+SELECT pg_tde_set_principal_key('rotated-principal-keyX', 'PG_TDE_GLOBAL', 'file-2', false);
+t
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- server restart
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
+-2|file-2|rotated-principal-keyX
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');
+-1|default_global_tablespace_keyring|tde-global-catalog-key
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;
+-- server restart
+psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
+-2|file-2|rotated-principal-keyX
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');
+-1|default_global_tablespace_keyring|tde-global-catalog-key
+SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
+t
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
+2|file-2|rotated-principal-key2
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info('PG_TDE_GLOBAL');
+-1|default_global_tablespace_keyring|tde-global-catalog-key
 DROP TABLE test_enc;
-DROP EXTENSION pg_tde;
+ALTER SYSTEM RESET pg_tde.inherit_global_providers;
+DROP EXTENSION pg_tde CASCADE;
+

--- a/contrib/pg_tde/t/expected/007_access_control.out
+++ b/contrib/pg_tde/t/expected/007_access_control.out
@@ -6,8 +6,6 @@ grant all ON database postgres TO test_access;
 psql:<stdin>:1: ERROR:  permission denied for function pg_tde_add_key_provider_file
 -- pg_tde_set_principal_key should also fail
 psql:<stdin>:1: ERROR:  permission denied for function pg_tde_set_principal_key
--- pg_tde_rotate_principal_key should give access denied error
-psql:<stdin>:1: ERROR:  permission denied for function pg_tde_rotate_principal_key
 -- grant key management access to test_access
 select pg_tde_grant_key_management_to_role('test_access');
 t
@@ -17,8 +15,6 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');
 2
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
-t
-SELECT pg_tde_rotate_principal_key('rotated-principal-key','file-2');
 t
 3
 SELECT pg_tde_list_all_key_providers();


### PR DESCRIPTION
This commit adds a new GUC variable, `pg_tde.inherit_global_providers` (ON by default) and changes several related API functions.

With these changes, it is now possible to use global key providers as key providers for database principal keys, when the variable is ON. When the variable is OFF existing global keyring uses will continue to work, but no new database configuration is allowed based on a global provider.

To allow a cleaner API with these changes, the following user interface changes are also included:
* the rotate_principal_key functions are now gone. Principal keys now can be rotated with the set_principal_key function instead.
* The set_principal_key function has a global and a "normal" overload.
* The server (WAL) principal key is now rotated with a separate function.
* Automatic key versioning is removed: keys are saved on the keyrings exactly with the name as it was specified by the user. On disk storage is unchanged, existing keys will continue to work, but will display the numeric version tag in postgres after this commit.

There's also an internal change about keyring numbering: after this commit, global providers are generated with negative numbers, and local providers are generated with positive numbers (as before). This allows the keyring code to differentiate between them without changint he disk format, as it can only refer one database Oid - a negative number identified a global key.

There's no update logic for this, when upgrading from the Beta, old global keys will continue to exist with positive IDs, but new global keys will receive negative IDs.
This means that old global keys won't be usable for local use, set_principal_key displays an appropriate error message for this situation.

The commit also renames a few internal variables/functions which were related to the changes and used misleading naming.