### PR TITLE
Fix typo in one versions of pg_tde_change_key_provider_kmip()

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-beta2.sql
+++ b/contrib/pg_tde/pg_tde--1.0-beta2.sql
@@ -211,7 +211,7 @@ AS $$
                             'host' VALUE COALESCE(kmip_host,''),
                             'port' VALUE kmip_port,
                             'caPath' VALUE COALESCE(kmip_ca_path,''),
-                            'certPath' VALUE COALESCE(vault_cert_path,'')));
+                            'certPath' VALUE COALESCE(kmip_cert_path,'')));
 $$
 LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION pg_tde_add_key_provider_kmip(PG_TDE_GLOBAL, 
@@ -425,7 +425,7 @@ AS $$
                             'host' VALUE COALESCE(kmip_host,''),
                             'port' VALUE kmip_port,
                             'caPath' VALUE COALESCE(kmip_ca_path,''),
-                            'certPath' VALUE COALESCE(vault_cert_path,'')));
+                            'certPath' VALUE COALESCE(kmip_cert_path,'')));
 $$
 LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION pg_tde_change_key_provider_kmip(PG_TDE_GLOBAL, 


### PR DESCRIPTION
There was a copy pasto in one of the arguments.

@dutow @dAdAbird Should we add a test case for this because apparently there was no coverage of this function?