### PR TITLE
Fixup for PG-1255: assertion hit during recovery

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -171,7 +171,7 @@ GetAllKeyringProviders(Oid dbOid)
 uint32
 redo_key_provider_info(KeyringProviderXLRecord *xlrec)
 {
-	return write_key_provider_info(&xlrec->provider, xlrec->database_id, xlrec->offset_in_file, true, false);
+	return write_key_provider_info(&xlrec->provider, xlrec->database_id, xlrec->offset_in_file, false, false);
 }
 
 void


### PR DESCRIPTION
If recovery reapplied a key provider the process crashed with an assertion because of an incorrectly specified flag. During recovery, it is perfectly fine if a key provider already has an ID - it would be strange if it didn't have one.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

