### PR TITLE
Improve consistency and clarity of how we refer to commands in our docs

### DIFF
--- a/contrib/pg_tde/README.md
+++ b/contrib/pg_tde/README.md
@@ -151,7 +151,7 @@ _See [Make Builds for Developers](https://github.com/percona/pg_tde/wiki/Make-bu
         ```
    7. You can encrypt existing table. It requires rewriting the table, so for large tables, it might take a considerable amount of time. 
         ```sql
-        ALTER TABLE table_name SET access method  tde_heap_basic;
+        ALTER TABLE table_name SET ACCESS METHOD tde_heap_basic;
         ```
 
 

--- a/contrib/pg_tde/documentation/docs/decrypt.md
+++ b/contrib/pg_tde/documentation/docs/decrypt.md
@@ -5,10 +5,10 @@
 If you encrypted a table with the `tde_heap` or `tde_heap_basic` access method and need to decrypt it, run the following command against the desired table (`mytable` in the example below):
 
 ```
-ALTER TABLE mytable SET access method heap;
+ALTER TABLE mytable SET ACCESS METHOD heap;
 ```
 
-Note that the `ALTER TABLE SET` command drops hint bits and this may affect the performance. Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
+Note that the `SET ACCESS METHOD` command drops hint bits and this may affect the performance. Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the `ALTER TABLE` command, run a simple "count(*)" on your tables:
 
 ```
 SELECT COUNT(*) FROM mytable;
@@ -27,7 +27,7 @@ The output returns `f` meaning that the table is no longer encrypted.
     In the same way you can re-encrypt the data with the `tde_heap_basic` access method. 
     
     ```
-    ALTER TABLE mytable SET access method tde_heap_basic;
+    ALTER TABLE mytable SET ACCESS METHOD tde_heap_basic;
     ```
     
     Note that the indexes and WAL files will no longer be encrypted.

--- a/contrib/pg_tde/documentation/docs/faq.md
+++ b/contrib/pg_tde/documentation/docs/faq.md
@@ -116,13 +116,13 @@ No, it's not yet supported. In our implementation we reply on OpenSSL libraries 
 
 ## Can I encrypt an existing table?
 
-Yes, you can encrypt an existing table. Run the ALTER TABLE command as follows:
+Yes, you can encrypt an existing table. Run the `ALTER TABLE` command as follows:
 
 ```
 ALTER TABLE table_name SET ACCESS METHOD tde_heap;
 ```
 
-Since the `ALTER TABLE SET` command drops hint bits and this may affect the performance, we recommend to run the `SELECT COUNT(*)` command. It checks every tuple for visibility and sets its hint bits. Read more in the [Changing existing table](test.md) section. 
+Since the `SET ACCESS METHOD` command drops hint bits and this may affect the performance, we recommend to run the `SELECT COUNT(*)` command. It checks every tuple for visibility and sets its hint bits. Read more in the [Changing existing table](test.md) section.
 
 ## Do I have to restart the database to encrypt the data?
 

--- a/contrib/pg_tde/documentation/docs/setup.md
+++ b/contrib/pg_tde/documentation/docs/setup.md
@@ -128,10 +128,10 @@ After you [enabled `pg_tde`](#enable-extension) and started the Percona Server f
 
 Here's how to do it:
 
-1. Enable WAL level encryption using the `ALTER SYSTEM SET` command. You need the privileges of the superuser to run this command:
+1. Enable WAL level encryption using the `ALTER SYSTEM` command. You need the privileges of the superuser to run this command:
 
     ```sql
-    ALTER SYSTEM set pg_tde.wal_encrypt = on;
+    ALTER SYSTEM SET pg_tde.wal_encrypt = on;
     ```
 
 2. Restart the server to apply the changes.

--- a/contrib/pg_tde/documentation/docs/table-access-method.md
+++ b/contrib/pg_tde/documentation/docs/table-access-method.md
@@ -55,13 +55,13 @@ Here's how you can set the new default table access method:
 
     === "via the SQL statement"
 
-        Use the `ALTER SYSTEM SET` command. This requires superuser or ALTER SYSTEM privileges.
+        Use the `ALTER SYSTEM` command. This requires superuser or `ALTER SYSTEM` privileges.
 
         This example shows how to set the `tde_heap` access method. Replace it with the `tde_heap_basic` if needed. 
     
 
         ```sql
-        ALTER SYSTEM SET default_table_access_method=tde_heap;
+        ALTER SYSTEM SET default_table_access_method = tde_heap;
         ```
 
     === "via the configuration file"
@@ -78,9 +78,9 @@ Here's how you can set the new default table access method:
 
         You can use the SET command to change the default table access method temporarily, for the current session. 
         
-        Unlike modifying the `postgresql.conf` file or using the ALTER SYSTEM SET command, the changes you make via the SET command don't persist after the session ends.
+        Unlike modifying the `postgresql.conf` file or using the `ALTER SYSTEM` command, the changes you make via the `SET` command don't persist after the session ends.
 
-        You also don't need to have the superuser privileges to run the SET command.
+        You also don't need to have the superuser privileges to run the `SET` command.
 
         You can run the SET command anytime during the session. This example shows how to set the `tde_heap` access method. Replace it with the `tde_heap_basic` if needed.
 

--- a/contrib/pg_tde/documentation/docs/test.md
+++ b/contrib/pg_tde/documentation/docs/test.md
@@ -50,10 +50,10 @@ You can encrypt an existing table. It requires rewriting the table, so for large
 Run the following command:
 
 ```
-ALTER TABLE table_name SET access method  tde_heap;
+ALTER TABLE table_name SET ACCESS METHOD tde_heap;
 ```
 
-Note that the `ALTER TABLE SET` command drops hint bits and this may affect the performance. Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the ALTER command, run a simple "count(*)" on your tables:
+Note that the `SET ACCESS METHOD` command drops hint bits and this may affect the performance. Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the `ALTER TABLE` command, run a simple "count(*)" on your tables:
 
 ```
 SELECT COUNT(*) FROM table_name;

--- a/contrib/pg_tde/documentation/docs/uninstall.md
+++ b/contrib/pg_tde/documentation/docs/uninstall.md
@@ -14,7 +14,7 @@ Here's how to do it:
 
 2. Run the `DROP EXTENSION` command against every database where you have enabled the `pg_tde` extension
 
-3. Modify the `shared_preload_libraries` and remove the 'pg_tde' from it. Use the `ALTER SYSTEM SET` command for this purpose
+3. Modify the `shared_preload_libraries` and remove the 'pg_tde' from it. Use the `ALTER SYSTEM` command for this purpose
 
 4. Start or restart the `postgre` instance to apply the changes.
 


### PR DESCRIPTION
- Always use "ALTER SYSTEM"
- Refer to subcommand of "ALTER TABLE" as "SET ACCESS METHOD"
- Uppercase all keywords of DDL commands
- Make sure commands use preformatted text

@nastena1606 Please take a look at this and if you do not like this or have any questions just tell me. I tried to refer to different commands in the way my brain is wired and that may for sure not be universal. :)