### PR TITLE
Clean up ubuntu-deps.sh

### DIFF
--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-sudo apt update
+sudo apt-get update
 
-sudo apt install -y libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev bison flex libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev pkg-config libselinux1-dev python3-dev uuid-dev liblz4-dev meson ninja-build gpg wget libcurl4-openssl-dev libxml2-utils docbook-xsl xsltproc
+sudo apt-get install -y libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev bison flex libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev pkg-config libselinux1-dev python3-dev uuid-dev liblz4-dev meson ninja-build gpg wget libcurl4-openssl-dev libxml2-utils docbook-xsl xsltproc
 
 bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
 # Test dependencies
-sudo apt install -y libipc-run-perl python3-pykmip libhttp-server-simple-perl
+sudo apt-get install -y libipc-run-perl python3-pykmip libhttp-server-simple-perl
 
 # Vault
 wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-sudo apt update && sudo apt install -y vault
+sudo apt-get update && sudo apt-get install -y vault

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -5,30 +5,36 @@ DEPS=(
     wget
     # Build
     bison
+    docbook-xml
     docbook-xsl
     flex
     gettext
+    libicu-dev
     libkrb5-dev
     libldap2-dev
     liblz4-dev
     libpam0g-dev
     libperl-dev
-    libreadline6-dev
+    libreadline-dev
     libselinux1-dev
     libssl-dev
     libsystemd-dev
-    libxml2
     libxml2-dev
     libxml2-utils
-    libxslt-dev
+    libxslt1-dev
+    libzstd-dev
+    lz4
+    mawk
     meson
-    pkg-config
+    perl
+    pkgconf
     python3-dev
     systemtap-sdt-dev
     tcl-dev
     uuid-dev
     xsltproc
     zlib1g-dev
+    zstd
     # Build pg_tde
     libcurl4-openssl-dev
     # Test

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -22,7 +22,6 @@ DEPS=(
     libxml2-utils
     libxslt-dev
     meson
-    ninja-build
     pkg-config
     python3-dev
     systemtap-sdt-dev

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -3,7 +3,6 @@
 DEPS=(
     # Setup
     wget
-    gpg
     # Build
     bison
     docbook-xsl
@@ -46,6 +45,6 @@ sudo apt-get install -y ${DEPS[@]}
 bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
 # Vault
-wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+wget -O - https://apt.releases.hashicorp.com/gpg | sudo tee /etc/apt/keyrings/hashicorp-archive-keyring.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp-archive-keyring.asc] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt-get update && sudo apt-get install -y vault

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -1,13 +1,49 @@
 #!/bin/bash
 
-sudo apt-get update
+DEPS=(
+    # Setup
+    wget
+    gpg
+    # Build
+    bison
+    docbook-xsl
+    flex
+    gettext
+    libkrb5-dev
+    libldap2-dev
+    liblz4-dev
+    libpam0g-dev
+    libperl-dev
+    libreadline6-dev
+    libselinux1-dev
+    libssl-dev
+    libsystemd-dev
+    libxml2
+    libxml2-dev
+    libxml2-utils
+    libxslt-dev
+    meson
+    ninja-build
+    pkg-config
+    python3-dev
+    systemtap-sdt-dev
+    tcl-dev
+    uuid-dev
+    xsltproc
+    zlib1g-dev
+    # Build pg_tde
+    libcurl4-openssl-dev
+    # Test
+    libipc-run-perl
+    # Test pg_tde
+    python3-pykmip
+    libhttp-server-simple-perl
+)
 
-sudo apt-get install -y libreadline6-dev systemtap-sdt-dev zlib1g-dev libssl-dev libpam0g-dev bison flex libxml2 libxml2-utils libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev libsystemd-dev gettext tcl-dev libperl-dev pkg-config libselinux1-dev python3-dev uuid-dev liblz4-dev meson ninja-build gpg wget libcurl4-openssl-dev libxml2-utils docbook-xsl xsltproc
+sudo apt-get update
+sudo apt-get install -y ${DEPS[@]}
 
 bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-
-# Test dependencies
-sudo apt-get install -y libipc-run-perl python3-pykmip libhttp-server-simple-perl
 
 # Vault
 wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg


### PR DESCRIPTION
This does the following to improve `ubuntu-deps.sh`.

- Put each dependency on a single line
- Install LLVM from Ubuntu like the official package does
- Sync the list of installed packages with upstream
- Remove a pointless GPG de-armor
- Use `apt-get` instead of `apt` to silence a warning
