### PR TITLE
Write `count(*)` in a consistent way in our documentation

### DIFF
--- a/contrib/pg_tde/documentation/docs/decrypt.md
+++ b/contrib/pg_tde/documentation/docs/decrypt.md
@@ -8,10 +8,10 @@ If you encrypted a table with the `tde_heap` or `tde_heap_basic` access method a
 ALTER TABLE mytable SET ACCESS METHOD heap;
 ```
 
-Note that the `SET ACCESS METHOD` command drops hint bits and this may affect the performance. Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the `ALTER TABLE` command, run a simple "count(*)" on your tables:
+Note that the `SET ACCESS METHOD` command drops hint bits and this may affect the performance. Running a plain `SELECT count(*)` or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the `ALTER TABLE` command, run a simple `count(*)` on your tables:
 
 ```
-SELECT COUNT(*) FROM mytable;
+SELECT count(*) FROM mytable;
 ```
 
 Check that the table is not encrypted:
@@ -32,10 +32,10 @@ The output returns `f` meaning that the table is no longer encrypted.
     
     Note that the indexes and WAL files will no longer be encrypted.
     
-    Run a simple "count(*)" on your table to check every tuple for visibility and set the hint bits:
+    Run a simple `count(*)` on your table to check every tuple for visibility and set the hint bits:
 
     ```
-    SELECT COUNT(*) FROM mytable;
+    SELECT count(*) FROM mytable;
     ```
 
 

--- a/contrib/pg_tde/documentation/docs/faq.md
+++ b/contrib/pg_tde/documentation/docs/faq.md
@@ -122,7 +122,7 @@ Yes, you can encrypt an existing table. Run the `ALTER TABLE` command as follows
 ALTER TABLE table_name SET ACCESS METHOD tde_heap;
 ```
 
-Since the `SET ACCESS METHOD` command drops hint bits and this may affect the performance, we recommend to run the `SELECT COUNT(*)` command. It checks every tuple for visibility and sets its hint bits. Read more in the [Changing existing table](test.md) section.
+Since the `SET ACCESS METHOD` command drops hint bits and this may affect the performance, we recommend to run the `SELECT count(*)` command. It checks every tuple for visibility and sets its hint bits. Read more in the [Changing existing table](test.md) section.
 
 ## Do I have to restart the database to encrypt the data?
 

--- a/contrib/pg_tde/documentation/docs/test.md
+++ b/contrib/pg_tde/documentation/docs/test.md
@@ -53,10 +53,10 @@ Run the following command:
 ALTER TABLE table_name SET ACCESS METHOD tde_heap;
 ```
 
-Note that the `SET ACCESS METHOD` command drops hint bits and this may affect the performance. Running a plain `SELECT, count(*)`, or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the `ALTER TABLE` command, run a simple "count(*)" on your tables:
+Note that the `SET ACCESS METHOD` command drops hint bits and this may affect the performance. Running a plain `SELECT count(*)` or `VACUUM` commands on the entire table will check every tuple for visibility and set its hint bits. Therefore, after executing the `ALTER TABLE` command, run a simple `count(*)` on your tables:
 
 ```
-SELECT COUNT(*) FROM table_name;
+SELECT count(*) FROM table_name;
 ```
 
 !!! hint


### PR DESCRIPTION
We used to mix both uppercase and lowercase and sometimes put it in quotes. Here we settle on always using `SELECT count(*)` or `count(*)` as a short form.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

