### PR TITLE
Remove `RelKeyData` and just use `PrincipalKey` directly

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_slot.c
+++ b/contrib/pg_tde/src/access/pg_tde_slot.c
@@ -45,7 +45,7 @@ typedef struct
 	 */
 	Buffer		buffer;			/* tuple's buffer, or InvalidBuffer */
 	char		decrypted_buffer[BLCKSZ];
-	RelKeyData *cached_relation_key;
+	InternalKey *cached_relation_key;
 } TDEBufferHeapTupleTableSlot;
 
 /*
@@ -62,7 +62,7 @@ static inline void tdeheap_tts_buffer_heap_store_tuple(TupleTableSlot *slot,
 													   HeapTuple tuple,
 													   Buffer buffer,
 													   bool transfer_pin);
-static inline RelKeyData *get_current_slot_relation_key(TDEBufferHeapTupleTableSlot *bslot, Relation rel);
+static inline InternalKey *get_current_slot_relation_key(TDEBufferHeapTupleTableSlot *bslot, Relation rel);
 static void
 tdeheap_tts_buffer_heap_init(TupleTableSlot *slot)
 {
@@ -553,7 +553,7 @@ PGTdeExecStoreBufferHeapTuple(Relation rel,
 
 	if (rel->rd_rel->relkind != RELKIND_TOASTVALUE)
 	{
-		RelKeyData *key = get_current_slot_relation_key(bslot, rel);
+		InternalKey *key = get_current_slot_relation_key(bslot, rel);
 
 		Assert(key != NULL);
 
@@ -595,7 +595,7 @@ PGTdeExecStorePinnedBufferHeapTuple(Relation rel,
 
 	if (rel->rd_rel->relkind != RELKIND_TOASTVALUE)
 	{
-		RelKeyData *key = get_current_slot_relation_key(bslot, rel);
+		InternalKey *key = get_current_slot_relation_key(bslot, rel);
 
 		slot_copytuple(bslot->decrypted_buffer, tuple);
 		PG_TDE_DECRYPT_TUPLE_EX(tuple, (HeapTuple) bslot->decrypted_buffer, key, "ExecStorePinnedBuffer");
@@ -610,7 +610,7 @@ PGTdeExecStorePinnedBufferHeapTuple(Relation rel,
 	return slot;
 }
 
-static inline RelKeyData *
+static inline InternalKey *
 get_current_slot_relation_key(TDEBufferHeapTupleTableSlot *bslot, Relation rel)
 {
 	Assert(bslot != NULL);

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -139,6 +139,7 @@ pg_tde_set_db_file_paths(Oid dbOid, char *map_path, char *keydata_path)
 
 #ifndef FRONTEND
 
+static RelKeyData *pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type);
 static int	pg_tde_file_header_write(char *tde_filename, int fd, TDEPrincipalKeyInfo *principal_key_info, off_t *bytes_written);
 static int32 pg_tde_write_map_entry(const RelFileLocator *rlocator, uint32 entry_type, char *db_map_path, TDEPrincipalKeyInfo *principal_key_info);
 static off_t pg_tde_write_one_map_entry(int fd, RelFileNumber rel_number, uint32 flags, int32 key_index, TDEMapEntry *map_entry, off_t *offset, const char *db_map_path);
@@ -168,7 +169,7 @@ pg_tde_create_heap_basic_key(const RelFileLocator *newrlocator)
 /*
  * Generate an encrypted key for the relation and store it in the keymap file.
  */
-RelKeyData *
+static RelKeyData *
 pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type)
 {
 	InternalKey int_key;

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1286,11 +1286,6 @@ pg_tde_read_one_keydata(int keydata_fd, int32 key_index, TDEPrincipalKey *princi
 	RelKeyData *enc_rel_key_data;
 	off_t		read_pos = 0;
 
-	/* Allocate and fill in the structure */
-	enc_rel_key_data = (RelKeyData *) palloc(sizeof(RelKeyData));
-
-	strncpy(enc_rel_key_data->principal_key_id.name, principal_key->keyInfo.keyId.name, PRINCIPAL_KEY_NAME_LEN);
-
 	/* Calculate the reading position in the file. */
 	read_pos += (key_index * INTERNAL_KEY_DAT_LEN) + TDE_FILE_HEADER_SIZE;
 
@@ -1306,6 +1301,11 @@ pg_tde_read_one_keydata(int keydata_fd, int32 key_index, TDEPrincipalKey *princi
 						key_index,
 						db_keydata_path)));
 	}
+
+	/* Allocate and fill in the structure */
+	enc_rel_key_data = (RelKeyData *) palloc(sizeof(RelKeyData));
+	strncpy(enc_rel_key_data->principal_key_id.name, principal_key->keyInfo.keyId.name, PRINCIPAL_KEY_NAME_LEN);
+	enc_rel_key_data->internal_key.ctx = NULL;
 
 	/* Read the encrypted key */
 	/* TODO: pgstat_report_wait_start / pgstat_report_wait_end */

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -58,7 +58,7 @@ PG_FUNCTION_INFO_V1(pg_tde_create_wal_key);
 Datum
 pg_tde_create_wal_key(PG_FUNCTION_ARGS)
 {
-	RelKeyData *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
+	InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
 
 	if (key != NULL)
 	{
@@ -77,7 +77,7 @@ TDEXlogCheckSane(void)
 {
 	if (EncryptXLog)
 	{
-		RelKeyData *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
+		InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
 
 		if (key == NULL)
 		{
@@ -149,7 +149,7 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset)
 	size_t		data_size = 0;
 	XLogPageHeader curr_page_hdr = &EncryptCurrentPageHrd;
 	XLogPageHeader enc_buf_page = NULL;
-	RelKeyData *key = GetTdeGlobaleRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID));
+	InternalKey *key = GetTdeGlobaleRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID));
 	off_t		enc_off;
 	size_t		page_size = XLOG_BLCKSZ - offset % XLOG_BLCKSZ;
 	uint32		iv_ctr = 0;
@@ -256,7 +256,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset)
 	char		iv_prefix[16] = {0,};
 	size_t		data_size = 0;
 	XLogPageHeader curr_page_hdr = &DecryptCurrentPageHrd;
-	RelKeyData *key = NULL;
+	InternalKey *key = NULL;
 	size_t		page_size = XLOG_BLCKSZ - offset % XLOG_BLCKSZ;
 	off_t		dec_off;
 	uint32		iv_ctr = 0;

--- a/contrib/pg_tde/src/catalog/tde_global_space.c
+++ b/contrib/pg_tde/src/catalog/tde_global_space.c
@@ -33,7 +33,7 @@
 void
 TDEInitGlobalKeys(const char *dir)
 {
-	RelKeyData *key;
+	InternalKey *key;
 
 	if (dir != NULL)
 		pg_tde_set_data_dir(dir);
@@ -50,7 +50,7 @@ TDEInitGlobalKeys(const char *dir)
 	 */
 	if (key != NULL)
 	{
-		pg_tde_put_key_into_cache(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), &key->internal_key);
+		pg_tde_put_key_into_cache(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), key);
 	}
 
 }

--- a/contrib/pg_tde/src/catalog/tde_global_space.c
+++ b/contrib/pg_tde/src/catalog/tde_global_space.c
@@ -33,12 +33,12 @@
 void
 TDEInitGlobalKeys(const char *dir)
 {
-	RelKeyData *ikey;
+	RelKeyData *key;
 
 	if (dir != NULL)
 		pg_tde_set_data_dir(dir);
 
-	ikey = pg_tde_get_key_from_file(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
+	key = pg_tde_get_key_from_file(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
 
 	/*
 	 * Internal Key should be in the TopMemmoryContext because of SSL
@@ -48,9 +48,9 @@ TDEInitGlobalKeys(const char *dir)
 	 * any changes to it have to remain local ot the backend. (see
 	 * https://github.com/percona-Lab/pg_tde/pull/214#discussion_r1648998317)
 	 */
-	if (ikey != NULL)
+	if (key != NULL)
 	{
-		pg_tde_put_key_into_cache(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), ikey);
+		pg_tde_put_key_into_cache(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), &key->internal_key);
 	}
 
 }

--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -59,7 +59,7 @@ pg_tde_internal_has_key(PG_FUNCTION_ARGS)
 	{
 		LOCKMODE	lockmode = AccessShareLock;
 		Relation	rel = table_open(tableOid, lockmode);
-		RelKeyData *rkd;
+		InternalKey *key;
 
 		if (
 #ifdef PERCONA_EXT
@@ -71,11 +71,11 @@ pg_tde_internal_has_key(PG_FUNCTION_ARGS)
 			PG_RETURN_BOOL(false);
 		}
 
-		rkd = GetSMGRRelationKey(rel->rd_locator);
+		key = GetSMGRRelationKey(rel->rd_locator);
 
 		table_close(rel, lockmode);
 
-		PG_RETURN_BOOL(rkd != NULL);
+		PG_RETURN_BOOL(key != NULL);
 	}
 }
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -68,9 +68,6 @@ extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info, bool truncate_existing, bool update_header);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
-extern RelKeyData *tde_create_rel_key(const RelFileLocator *locator, InternalKey *key, TDEPrincipalKeyInfo *principal_key_info);
-extern RelKeyData *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *rel_key_data, Oid dbOid);
-extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *enc_rel_key_data, Oid dbOid);
 extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
 extern void pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -50,17 +50,17 @@ typedef struct XLogRelKey
 	TDEPrincipalKeyInfo pkInfo;
 } XLogRelKey;
 
-extern RelKeyData *pg_tde_create_smgr_key(const RelFileLocator *newrlocator);
-extern RelKeyData *pg_tde_create_global_key(const RelFileLocator *newrlocator);
-extern RelKeyData *pg_tde_create_heap_basic_key(const RelFileLocator *newrlocator);
+extern InternalKey *pg_tde_create_smgr_key(const RelFileLocator *newrlocator);
+extern InternalKey *pg_tde_create_global_key(const RelFileLocator *newrlocator);
+extern InternalKey *pg_tde_create_heap_basic_key(const RelFileLocator *newrlocator);
 extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, RelKeyData *enc_rel_key_data, TDEPrincipalKeyInfo *principal_key_info);
 extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator, uint32 key_type);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);
 
-extern RelKeyData *GetRelationKey(RelFileLocator rel, uint32 entry_type, bool no_map_ok);
-extern RelKeyData *GetSMGRRelationKey(RelFileLocator rel);
-extern RelKeyData *GetHeapBaiscRelationKey(RelFileLocator rel);
-extern RelKeyData *GetTdeGlobaleRelationKey(RelFileLocator rel);
+extern InternalKey *GetRelationKey(RelFileLocator rel, uint32 entry_type, bool no_map_ok);
+extern InternalKey *GetSMGRRelationKey(RelFileLocator rel);
+extern InternalKey *GetHeapBaiscRelationKey(RelFileLocator rel);
+extern InternalKey *GetTdeGlobaleRelationKey(RelFileLocator rel);
 
 extern void pg_tde_delete_tde_files(Oid dbOid);
 
@@ -73,6 +73,6 @@ extern void pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFile
 
 const char *tde_sprint_key(InternalKey *k);
 
-extern RelKeyData *pg_tde_put_key_into_cache(const RelFileLocator *locator, RelKeyData *key);
+extern InternalKey *pg_tde_put_key_into_cache(const RelFileLocator *locator, InternalKey *key);
 
 #endif							/* PG_TDE_MAP_H */

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -36,24 +36,17 @@ typedef struct InternalKey
 
 #define INTERNAL_KEY_DAT_LEN	offsetof(InternalKey, ctx)
 
-typedef struct RelKeyData
-{
-	TDEPrincipalKeyId principal_key_id;
-	InternalKey internal_key;
-} RelKeyData;
-
-
 typedef struct XLogRelKey
 {
 	RelFileLocator rlocator;
-	RelKeyData	relKey;
+	InternalKey relKey;
 	TDEPrincipalKeyInfo pkInfo;
 } XLogRelKey;
 
 extern InternalKey *pg_tde_create_smgr_key(const RelFileLocator *newrlocator);
 extern InternalKey *pg_tde_create_global_key(const RelFileLocator *newrlocator);
 extern InternalKey *pg_tde_create_heap_basic_key(const RelFileLocator *newrlocator);
-extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, RelKeyData *enc_rel_key_data, TDEPrincipalKeyInfo *principal_key_info);
+extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, InternalKey *enc_rel_key_data, TDEPrincipalKeyInfo *principal_key_info);
 extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator, uint32 key_type);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);
 
@@ -68,7 +61,7 @@ extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info, bool truncate_existing, bool update_header);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
-extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
+extern InternalKey *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
 extern void pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *oldrlocator);
 
 const char *tde_sprint_key(InternalKey *k);

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -53,7 +53,6 @@ typedef struct XLogRelKey
 extern RelKeyData *pg_tde_create_smgr_key(const RelFileLocator *newrlocator);
 extern RelKeyData *pg_tde_create_global_key(const RelFileLocator *newrlocator);
 extern RelKeyData *pg_tde_create_heap_basic_key(const RelFileLocator *newrlocator);
-extern RelKeyData *pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type);
 extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, RelKeyData *enc_rel_key_data, TDEPrincipalKeyInfo *principal_key_info);
 extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator, uint32 key_type);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -17,10 +17,8 @@
 #include "access/pg_tde_tdemap.h"
 #include "keyring/keyring_api.h"
 
-extern void
-			pg_tde_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, RelKeyData *key, const char *context);
-extern void
-			pg_tde_crypt_tuple(HeapTuple tuple, HeapTuple out_tuple, RelKeyData *key, const char *context);
+extern void pg_tde_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, const char *context);
+extern void pg_tde_crypt_tuple(HeapTuple tuple, HeapTuple out_tuple, InternalKey *key, const char *context);
 
 /* A wrapper to encrypt a tuple before adding it to the buffer */
 extern OffsetNumber

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -50,7 +50,7 @@ extern OffsetNumber
 		pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, "ENCRYPT-PAGE-ITEM"); \
 	} while(0)
 
-extern void AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, RelKeyData *rel_key_data, RelKeyData **p_enc_rel_key_data, size_t *enc_key_bytes);
-extern void AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, RelKeyData **p_rel_key_data, RelKeyData *enc_rel_key_data, size_t *key_bytes);
+extern void AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey *rel_key_data, InternalKey **p_enc_rel_key_data, size_t *enc_key_bytes);
+extern void AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey **p_rel_key_data, InternalKey *enc_rel_key_data, size_t *key_bytes);
 
 #endif							/* ENC_TDE_H */

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -93,7 +93,7 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 		if (rkd2 != NULL)
 		{
 			/* create a new key for the new file */
-			return pg_tde_create_key_map_entry(&reln->smgr_rlocator.locator, TDE_KEY_TYPE_SMGR);
+			return pg_tde_create_smgr_key(&reln->smgr_rlocator.locator);
 		}
 	}
 

--- a/contrib/pg_tde/src16/access/pg_tdetoast.c
+++ b/contrib/pg_tde/src16/access/pg_tdetoast.c
@@ -44,7 +44,7 @@ static void tdeheap_toast_tuple_externalize(ToastTupleContext *ttc,
 static Datum tdeheap_toast_save_datum(Relation rel, Datum value,
 								struct varlena *oldexternal,
 								int options);
-static void tdeheap_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *keys);
+static void tdeheap_toast_encrypt(Pointer dval, Oid valueid, InternalKey *keys);
 static bool toastrel_valueid_exists(Relation toastrel, Oid valueid);
 static bool toastid_valueid_exists(Oid toastrelid, Oid valueid);
 
@@ -657,7 +657,7 @@ tdeheap_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 	int			validIndex;
 	SnapshotData SnapshotToast;
 	char		decrypted_data[TOAST_MAX_CHUNK_SIZE];
-	RelKeyData *key = GetHeapBaiscRelationKey(toastrel->rd_locator);
+	InternalKey *key = GetHeapBaiscRelationKey(toastrel->rd_locator);
 	char		iv_prefix[16] = {0,};
 
 
@@ -842,7 +842,7 @@ tdeheap_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 // TODO: these should be in their own file so we can proplerly autoupdate them
 /* pg_tde extension */
 static void
-tdeheap_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *key)
+tdeheap_toast_encrypt(Pointer dval, Oid valueid, InternalKey *key)
 {
 	int32		data_size =0;
 	char*		data_p;

--- a/contrib/pg_tde/src17/access/pg_tdetoast.c
+++ b/contrib/pg_tde/src17/access/pg_tdetoast.c
@@ -44,7 +44,7 @@ static void tdeheap_toast_tuple_externalize(ToastTupleContext *ttc,
 static Datum tdeheap_toast_save_datum(Relation rel, Datum value,
 								struct varlena *oldexternal,
 								int options);
-static void tdeheap_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *keys);
+static void tdeheap_toast_encrypt(Pointer dval, Oid valueid, InternalKey *key);
 static bool toastrel_valueid_exists(Relation toastrel, Oid valueid);
 static bool toastid_valueid_exists(Oid toastrelid, Oid valueid);
 
@@ -657,7 +657,7 @@ tdeheap_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 	int			validIndex;
 	SnapshotData SnapshotToast;
 	char		decrypted_data[TOAST_MAX_CHUNK_SIZE];
-	RelKeyData *key = GetHeapBaiscRelationKey(toastrel->rd_locator);
+	InternalKey *key = GetHeapBaiscRelationKey(toastrel->rd_locator);
 	char		iv_prefix[16] = {0,};
 
 
@@ -842,7 +842,7 @@ tdeheap_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 // TODO: these should be in their own file so we can proplerly autoupdate them
 /* pg_tde extension */
 static void
-tdeheap_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *key)
+tdeheap_toast_encrypt(Pointer dval, Oid valueid, InternalKey *key)
 {
 	int32		data_size =0;
 	char*		data_p;

--- a/contrib/pg_tde/typedefs.list
+++ b/contrib/pg_tde/typedefs.list
@@ -40,7 +40,6 @@ ProviderScanType
 PruneFreezeResult
 RelKeyCache
 RelKeyCacheRec
-RelKeyData
 RewriteMappingDataEntry
 RewriteMappingDataEntry
 RewriteMappingFile


### PR DESCRIPTION
These principal key names stored in `RelKeyData` are not used for anything anymore but just waste memory
    and make the code more complex than necessary. Plus when we in the
    future will want to store internal keys in the cache which are not
    connected to any principal key, e.g. for temporary tables or
    temporary files, this will force us to invent some dummy data
    which would even more complicate the code.

Plus since the name of the principal key for each internal key is not even
    written to the key file or map file there is no reason for it to exist
    at all.