### PR TITLE
Fix buffer overflow when writing to key cache

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1512,7 +1512,7 @@ pg_tde_put_key_into_cache(const RelFileLocator *rlocator, RelKeyData *key)
 
 	rec->dbOid = rlocator->dbOid;
 	rec->relNumber = rlocator->relNumber;
-	memcpy(&rec->key, key, sizeof(RelKeyCacheRec));
+	rec->key = *key;
 	tde_rel_key_cache.len++;
 
 	return &rec->key;


### PR DESCRIPTION
The `memcpy()` copied `sizeof(RelKeyCacheRec)` instead of `sizeof(RelKeyData) bytes which is an 8 byte buffer overflow on my machine. Due to the alignment it is likely harmless in virtually all cases but it is obviously not a good thing.

Instead of using `memcpy()` we can just use a normal assignment here which type checks properly.