### PR TITLE
PG-1376: Fix warning in set_default_principal_key

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -68,7 +68,6 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 
 \c regression_pg_tde
 SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
-WARNING:  you don't own a lock of type AccessExclusiveLock
  pg_tde_set_default_principal_key 
 ----------------------------------
  t

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -1080,7 +1080,7 @@ pg_tde_update_global_principal_key_everywhere(TDEPrincipalKey *oldKey, TDEPrinci
 	}
 
 	systable_endscan(scan);
-	table_close(rel, AccessExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 }
 
 Datum


### PR DESCRIPTION
Lock release used an incorrect lock type after changing lock type during PR review. This commit fixes the issue by correcting the release call.
