### PR TITLE
PG-1222 Second attempt at avoiding RelFileNumber collissions

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -67,7 +67,6 @@ typedef struct TDEFileHeader
 	TDEPrincipalKeyInfo principal_key_info;
 } TDEFileHeader;
 
-/* We do not need the dbOid since the entries are stored in a file per db */
 typedef struct TDEMapEntry
 {
 	RelFileNumber relNumber;
@@ -115,12 +114,12 @@ RelKeyCache tde_rel_key_cache = {
 	.cap = 0,
 };
 
-static int32 pg_tde_process_map_entry(RelFileNumber rel_number, uint32 key_type, char *db_map_path, off_t *offset, bool should_delete);
+static int32 pg_tde_process_map_entry(const RelFileLocator *rlocator, uint32 key_type, char *db_map_path, off_t *offset, bool should_delete);
 static InternalKey *pg_tde_read_keydata(char *db_keydata_path, int32 key_index, TDEPrincipalKey *principal_key);
 static InternalKey *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, InternalKey *enc_rel_key_data, Oid dbOid);
 static int	pg_tde_open_file_basic(char *tde_filename, int fileFlags, bool ignore_missing);
 static int	pg_tde_file_header_read(char *tde_filename, int fd, TDEFileHeader *fheader, bool *is_new_file, off_t *bytes_read);
-static bool pg_tde_read_one_map_entry(int fd, RelFileNumber rel_number, int flags, TDEMapEntry *map_entry, off_t *offset);
+static bool pg_tde_read_one_map_entry(int fd, const RelFileLocator *rlocator, int flags, TDEMapEntry *map_entry, off_t *offset);
 static InternalKey *pg_tde_read_one_keydata(int keydata_fd, int32 key_index, TDEPrincipalKey *principal_key);
 static int	pg_tde_open_file(char *tde_filename, TDEPrincipalKeyInfo *principal_key_info, bool update_header, int fileFlags, bool *is_new_file, off_t *curr_pos);
 static InternalKey *pg_tde_get_key_from_cache(const RelFileLocator *rlocator, uint32 key_type);
@@ -143,7 +142,7 @@ static InternalKey *pg_tde_create_key_map_entry(const RelFileLocator *newrlocato
 static InternalKey *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, InternalKey *rel_key_data, Oid dbOid);
 static int	pg_tde_file_header_write(char *tde_filename, int fd, TDEPrincipalKeyInfo *principal_key_info, off_t *bytes_written);
 static int32 pg_tde_write_map_entry(const RelFileLocator *rlocator, uint32 entry_type, char *db_map_path, TDEPrincipalKeyInfo *principal_key_info);
-static off_t pg_tde_write_one_map_entry(int fd, RelFileNumber rel_number, uint32 flags, int32 key_index, TDEMapEntry *map_entry, off_t *offset, const char *db_map_path);
+static off_t pg_tde_write_one_map_entry(int fd, const RelFileLocator *rlocator, uint32 flags, int32 key_index, TDEMapEntry *map_entry, off_t *offset, const char *db_map_path);
 static void pg_tde_write_keydata(char *db_keydata_path, TDEPrincipalKeyInfo *principal_key_info, int32 key_index, InternalKey *enc_rel_key_data);
 static void pg_tde_write_one_keydata(int keydata_fd, int32 key_index, InternalKey *enc_rel_key_data);
 static int	keyrotation_init_file(TDEPrincipalKeyInfo *new_principal_key_info, char *rotated_filename, char *filename, bool *is_new_file, off_t *curr_pos);
@@ -389,7 +388,7 @@ pg_tde_write_map_entry(const RelFileLocator *rlocator, uint32 entry_type, char *
 	while (1)
 	{
 		prev_pos = curr_pos;
-		found = pg_tde_read_one_map_entry(map_fd, InvalidRelFileNumber, MAP_ENTRY_EMPTY, &map_entry, &curr_pos);
+		found = pg_tde_read_one_map_entry(map_fd, NULL, MAP_ENTRY_EMPTY, &map_entry, &curr_pos);
 
 		/*
 		 * We either reach EOF or found an empty slot in the middle of the
@@ -407,7 +406,7 @@ pg_tde_write_map_entry(const RelFileLocator *rlocator, uint32 entry_type, char *
 	 * free entry
 	 */
 	curr_pos = prev_pos;
-	pg_tde_write_one_map_entry(map_fd, rlocator->relNumber, entry_type, key_index, &map_entry, &prev_pos, db_map_path);
+	pg_tde_write_one_map_entry(map_fd, rlocator, entry_type, key_index, &map_entry, &prev_pos, db_map_path);
 
 	/* Let's close the file. */
 	close(map_fd);
@@ -423,14 +422,14 @@ pg_tde_write_map_entry(const RelFileLocator *rlocator, uint32 entry_type, char *
  * map file.
  */
 static off_t
-pg_tde_write_one_map_entry(int fd, RelFileNumber rel_number, uint32 flags, int32 key_index, TDEMapEntry *map_entry, off_t *offset, const char *db_map_path)
+pg_tde_write_one_map_entry(int fd, const RelFileLocator *rlocator, uint32 flags, int32 key_index, TDEMapEntry *map_entry, off_t *offset, const char *db_map_path)
 {
 	int			bytes_written = 0;
 
 	Assert(map_entry);
 
 	/* Fill in the map entry structure */
-	map_entry->relNumber = rel_number;
+	map_entry->relNumber = (rlocator == NULL) ? 0 : rlocator->relNumber;
 	map_entry->flags = flags;
 	map_entry->key_index = key_index;
 
@@ -558,7 +557,7 @@ pg_tde_delete_key_map_entry(const RelFileLocator *rlocator, uint32 key_type)
 	errno = 0;
 	/* Remove the map entry if found */
 	LWLockAcquire(lock_files, LW_EXCLUSIVE);
-	key_index = pg_tde_process_map_entry(rlocator->relNumber, key_type, db_map_path, &offset, false);
+	key_index = pg_tde_process_map_entry(rlocator, key_type, db_map_path, &offset, false);
 	LWLockRelease(lock_files);
 
 	if (key_index == -1)
@@ -601,7 +600,7 @@ pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t
 	pg_tde_set_db_file_paths(rlocator->dbOid, db_map_path, NULL);
 
 	/* Remove the map entry if found */
-	key_index = pg_tde_process_map_entry(rlocator->relNumber, key_type, db_map_path, &offset, true);
+	key_index = pg_tde_process_map_entry(rlocator, key_type, db_map_path, &offset, true);
 
 	if (key_index == -1)
 	{
@@ -705,9 +704,10 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 	{
 		TDEMapEntry read_map_entry,
 					write_map_entry;
+		RelFileLocator rloc;
 
 		prev_pos[OLD_PRINCIPAL_KEY] = curr_pos[OLD_PRINCIPAL_KEY];
-		found = pg_tde_read_one_map_entry(m_fd[OLD_PRINCIPAL_KEY], InvalidRelFileNumber, MAP_ENTRY_VALID, &read_map_entry, &curr_pos[OLD_PRINCIPAL_KEY]);
+		found = pg_tde_read_one_map_entry(m_fd[OLD_PRINCIPAL_KEY], NULL, MAP_ENTRY_VALID, &read_map_entry, &curr_pos[OLD_PRINCIPAL_KEY]);
 
 		/* We either reach EOF */
 		if (prev_pos[OLD_PRINCIPAL_KEY] == curr_pos[OLD_PRINCIPAL_KEY])
@@ -716,6 +716,9 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 		/* We didn't find a valid entry */
 		if (found == false)
 			continue;
+
+		rloc.relNumber = read_map_entry.relNumber;
+		rloc.dbOid = principal_key->keyInfo.databaseId;
 
 		/* Let's get the decrypted key and re-encrypt it with the new key. */
 		enc_rel_key_data[OLD_PRINCIPAL_KEY] = pg_tde_read_one_keydata(k_fd[OLD_PRINCIPAL_KEY], key_index[OLD_PRINCIPAL_KEY], principal_key);
@@ -726,7 +729,7 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 
 		/* Write the given entry at the location pointed by prev_pos */
 		prev_pos[NEW_PRINCIPAL_KEY] = curr_pos[NEW_PRINCIPAL_KEY];
-		curr_pos[NEW_PRINCIPAL_KEY] = pg_tde_write_one_map_entry(m_fd[NEW_PRINCIPAL_KEY], read_map_entry.relNumber, read_map_entry.flags, key_index[NEW_PRINCIPAL_KEY], &write_map_entry, &prev_pos[NEW_PRINCIPAL_KEY], m_path[NEW_PRINCIPAL_KEY]);
+		curr_pos[NEW_PRINCIPAL_KEY] = pg_tde_write_one_map_entry(m_fd[NEW_PRINCIPAL_KEY], &rloc, read_map_entry.flags, key_index[NEW_PRINCIPAL_KEY], &write_map_entry, &prev_pos[NEW_PRINCIPAL_KEY], m_path[NEW_PRINCIPAL_KEY]);
 		pg_tde_write_one_keydata(k_fd[NEW_PRINCIPAL_KEY], key_index[NEW_PRINCIPAL_KEY], enc_rel_key_data[NEW_PRINCIPAL_KEY]);
 
 		/* Increment the key index for the new principal key */
@@ -882,7 +885,7 @@ pg_tde_move_rel_key(const RelFileLocator *newrlocator, const RelFileLocator *old
 	/*
 	 * We don't use internal_key cache to avoid locking complications.
 	 */
-	key_index = pg_tde_process_map_entry(oldrlocator->relNumber, MAP_ENTRY_VALID, db_map_path, &offset, false);
+	key_index = pg_tde_process_map_entry(oldrlocator, MAP_ENTRY_VALID, db_map_path, &offset, false);
 	Assert(key_index != -1);
 
 	enc_key = pg_tde_read_keydata(db_keydata_path, key_index, principal_key);
@@ -968,7 +971,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool n
 		return NULL;
 	}
 	/* Read the map entry and get the index of the relation key */
-	key_index = pg_tde_process_map_entry(rlocator->relNumber, key_type, db_map_path, &offset, false);
+	key_index = pg_tde_process_map_entry(rlocator, key_type, db_map_path, &offset, false);
 
 	if (key_index == -1)
 	{
@@ -994,7 +997,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool n
  * The function expects that the offset points to a valid map start location.
  */
 static int32
-pg_tde_process_map_entry(RelFileNumber rel_number, uint32 key_type, char *db_map_path, off_t *offset, bool should_delete)
+pg_tde_process_map_entry(const RelFileLocator *rlocator, uint32 key_type, char *db_map_path, off_t *offset, bool should_delete)
 {
 	File		map_fd = -1;
 	int32		key_index = 0;
@@ -1044,7 +1047,7 @@ pg_tde_process_map_entry(RelFileNumber rel_number, uint32 key_type, char *db_map
 	while (1)
 	{
 		prev_pos = curr_pos;
-		found = pg_tde_read_one_map_entry(map_fd, rel_number, key_type, &map_entry, &curr_pos);
+		found = pg_tde_read_one_map_entry(map_fd, rlocator, key_type, &map_entry, &curr_pos);
 
 		/* We've reached EOF */
 		if (curr_pos == prev_pos)
@@ -1057,7 +1060,7 @@ pg_tde_process_map_entry(RelFileNumber rel_number, uint32 key_type, char *db_map
 			/* Mark the entry pointed by prev_pos as free */
 			if (should_delete)
 			{
-				pg_tde_write_one_map_entry(map_fd, InvalidRelFileNumber, MAP_ENTRY_EMPTY, 0, &map_entry, &prev_pos, db_map_path);
+				pg_tde_write_one_map_entry(map_fd, NULL, MAP_ENTRY_EMPTY, 0, &map_entry, &prev_pos, db_map_path);
 			}
 #endif
 			break;
@@ -1229,7 +1232,7 @@ pg_tde_file_header_read(char *tde_filename, int fd, TDEFileHeader *fheader, bool
  * comparing old and new value of the offset.
  */
 static bool
-pg_tde_read_one_map_entry(File map_file, RelFileNumber rel_number, int flags, TDEMapEntry *map_entry, off_t *offset)
+pg_tde_read_one_map_entry(File map_file, const RelFileLocator *rlocator, int flags, TDEMapEntry *map_entry, off_t *offset)
 {
 	bool		found;
 	off_t		bytes_read = 0;
@@ -1251,7 +1254,7 @@ pg_tde_read_one_map_entry(File map_file, RelFileNumber rel_number, int flags, TD
 	found = (map_entry->flags & flags);
 
 	/* If a valid rlocator is provided, let's compare and set found value */
-	found &= (rel_number == InvalidRelFileNumber) ? true : (map_entry->relNumber == rel_number);
+	found &= (rlocator == NULL) ? true : (map_entry->relNumber == rlocator->relNumber);
 
 	return found;
 }

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -84,8 +84,7 @@ typedef struct TDEMapFilePath
 
 typedef struct RelKeyCacheRec
 {
-	Oid			dbOid;
-	RelFileNumber relNumber;
+	RelFileLocator locator;
 	InternalKey key;
 } RelKeyCacheRec;
 
@@ -1402,7 +1401,7 @@ pg_tde_get_key_from_cache(const RelFileLocator *rlocator, uint32 key_type)
 		RelKeyCacheRec *rec = tde_rel_key_cache.data + i;
 
 		if ((rlocator->relNumber == InvalidRelFileNumber ||
-			 (rec->dbOid == rlocator->dbOid && rec->relNumber == rlocator->relNumber)) &&
+			 RelFileLocatorEquals(rec->locator, *rlocator)) &&
 			rec->key.rel_type & key_type)
 		{
 			return &rec->key;
@@ -1492,8 +1491,7 @@ pg_tde_put_key_into_cache(const RelFileLocator *rlocator, InternalKey *key)
 
 	rec = tde_rel_key_cache.data + tde_rel_key_cache.len;
 
-	rec->dbOid = rlocator->dbOid;
-	rec->relNumber = rlocator->relNumber;
+	rec->locator = *rlocator;
 	rec->key = *key;
 	tde_rel_key_cache.len++;
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -43,7 +43,7 @@ typedef struct XLogRelKey
 	TDEPrincipalKeyInfo pkInfo;
 } XLogRelKey;
 
-extern InternalKey *pg_tde_create_smgr_key(const RelFileLocator *newrlocator);
+extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
 extern InternalKey *pg_tde_create_global_key(const RelFileLocator *newrlocator);
 extern InternalKey *pg_tde_create_heap_basic_key(const RelFileLocator *newrlocator);
 extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, InternalKey *enc_rel_key_data, TDEPrincipalKeyInfo *principal_key_info);
@@ -51,7 +51,7 @@ extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator, uint32 k
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);
 
 extern InternalKey *GetRelationKey(RelFileLocator rel, uint32 entry_type, bool no_map_ok);
-extern InternalKey *GetSMGRRelationKey(RelFileLocator rel);
+extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
 extern InternalKey *GetHeapBaiscRelationKey(RelFileLocator rel);
 extern InternalKey *GetTdeGlobaleRelationKey(RelFileLocator rel);
 

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -61,7 +61,7 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 	event = GetCurrentTdeCreateEvent();
 
 	/* see if we have a key for the relation, and return if yes */
-	key = GetSMGRRelationKey(reln->smgr_rlocator.locator);
+	key = GetSMGRRelationKey(reln->smgr_rlocator);
 
 	if (key != NULL)
 	{
@@ -71,7 +71,7 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 	/* if this is a CREATE TABLE, we have to generate the key */
 	if (event->encryptMode == true && event->eventType == TDE_TABLE_CREATE_EVENT && can_create)
 	{
-		return pg_tde_create_smgr_key(&reln->smgr_rlocator.locator);
+		return pg_tde_create_smgr_key(&reln->smgr_rlocator);
 	}
 
 	/* if this is a CREATE INDEX, we have to load the key based on the table */
@@ -82,18 +82,19 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 		 * Later we might modify the map infrastructure to support the same
 		 * keys
 		 */
-		return pg_tde_create_smgr_key(&reln->smgr_rlocator.locator);
+		return pg_tde_create_smgr_key(&reln->smgr_rlocator);
 	}
 
 	/* check if we had a key for the old locator, if there's one */
 	if (old_locator != NULL && can_create)
 	{
-		InternalKey *key2 = GetSMGRRelationKey(*old_locator);
+		RelFileLocatorBackend rlocator = {.locator = *old_locator,.backend = reln->smgr_rlocator.backend};
+		InternalKey *key2 = GetSMGRRelationKey(rlocator);
 
 		if (key2 != NULL)
 		{
 			/* create a new key for the new file */
-			return pg_tde_create_smgr_key(&reln->smgr_rlocator.locator);
+			return pg_tde_create_smgr_key(&reln->smgr_rlocator);
 		}
 	}
 


### PR DESCRIPTION
In the last attempt I forgot that unique identifier for a relations file is (tablespace, database, RelFileNunber) or (tablespace, database, RelFileNumber, backend) for temporary relations. So to fix this we do the following:

- Cache keys with the `RelFileLocator` as key  (tablespace, database, RelFileNunber)
- Revert my previous attempt at cleaning up the APIs for writing the map files
- Add tablespace as a new field to the map file
- Do not try to save internal keys for temporary relations to disk to avoid the mess with them being per backend

The last part breaks `pg_tde_is_encrypted()` for temporary relations in other backends but I think that is a fine tradeoff and I made sure it throws an error instead of just returning false incorrectly.
