### PR TITLE
PG-1380 Add support for `pg_tde_is_encrypted()` on indexes and sequences

### DIFF
--- a/ci_scripts/backup/sql/verify_incremental_data.sql
+++ b/ci_scripts/backup/sql/verify_incremental_data.sql
@@ -83,7 +83,7 @@ WHERE tde_table.id IS NULL;
 -- 10. Verify tables are encrypted
 -- ===============================================
 -- Verify all tables exist and are encrypted
-SELECT tablename, pg_tde_is_encrypted(tablename::TEXT) AS is_encrypted
+SELECT tablename, pg_tde_is_encrypted(tablename::regclass) AS is_encrypted
 FROM pg_tables
 WHERE schemaname = 'public'
 AND tablename IN ('tde_table', 'tde_child', 'part1','part_table')

--- a/ci_scripts/backup/sql/verify_sample_data.sql
+++ b/ci_scripts/backup/sql/verify_sample_data.sql
@@ -128,7 +128,7 @@ WHERE dept.deptno IS NULL;
 -- 9. Verify tables are encrypted
 -- ===============================================
 -- Verify all tables exist and are encrypted
-SELECT tablename, pg_tde_is_encrypted(tablename::TEXT) AS is_encrypted
+SELECT tablename, pg_tde_is_encrypted(tablename::regclass) AS is_encrypted
 FROM pg_tables
 WHERE schemaname = 'public'
 AND tablename IN ('dept', 'emp', 'jobhist')

--- a/contrib/pg_tde/README.md
+++ b/contrib/pg_tde/README.md
@@ -169,4 +169,4 @@ The extension provides the following helper functions:
 
 ### pg_tde_is_encrypted(tablename)
 
-Returns `t` if the table is encrypted (uses the tde_heap_basic access method), or `f` otherwise.
+Returns `t` if the relation is encrypted, or `f` otherwise.

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -95,7 +95,7 @@ SELECT pg_tde_rotate_principal_key(NULL, 'name-of-the-new-provider');
 
 Tells if a relation is encrypted using the `pg_tde` extension or not.
 
-To verify a table encryption, run the following statement:
+To verify that a table is encrypted, run the following statement:
 
 ```
 SELECT pg_tde_is_encrypted('table_name');

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -93,7 +93,7 @@ SELECT pg_tde_rotate_principal_key(NULL, 'name-of-the-new-provider');
 
 ## pg_tde_is_encrypted
 
-Tells if a table is encrypted using the `tde_heap` access method or not.
+Tells if a relation is encrypted using the `pg_tde` extension or not.
 
 To verify a table encryption, run the following statement:
 
@@ -101,8 +101,10 @@ To verify a table encryption, run the following statement:
 SELECT pg_tde_is_encrypted('table_name');
 ```
 
-You can also verify if the table in a custom schema is encrypted. Pass teh schema name for the function as follows:
+You can also verify if the table in a custom schema is encrypted. Pass the schema name for the function as follows:
 
 ```
 SELECT pg_tde_is_encrypted('schema.table_name');
 ```
+
+This can additoonally be used the verify that indexes and sequences are encrypted.

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -50,12 +50,6 @@ SELECT pg_tde_is_encrypted('test_norm');
  f
 (1 row)
 
-SELECT pg_tde_is_encrypted('public.test_enc');
- pg_tde_is_encrypted 
----------------------
- t
-(1 row)
-
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
  key_provider_id | key_provider_name |  principal_key_name   

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -50,6 +50,30 @@ SELECT pg_tde_is_encrypted('test_norm');
  f
 (1 row)
 
+SELECT pg_tde_is_encrypted('test_enc_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_norm_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_enc_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_norm_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
  key_provider_id | key_provider_name |  principal_key_name   

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted_basic.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted_basic.out
@@ -52,6 +52,30 @@ SELECT pg_tde_is_encrypted('test_norm');
  f
 (1 row)
 
+SELECT pg_tde_is_encrypted('test_enc_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_norm_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_enc_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_norm_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
  key_provider_id | key_provider_name |  principal_key_name   

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted_basic.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted_basic.out
@@ -52,12 +52,6 @@ SELECT pg_tde_is_encrypted('test_norm');
  f
 (1 row)
 
-SELECT pg_tde_is_encrypted('public.test_enc');
- pg_tde_is_encrypted 
----------------------
- t
-(1 row)
-
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
  key_provider_id | key_provider_name |  principal_key_name   

--- a/contrib/pg_tde/pg_tde--1.0-beta2.sql
+++ b/contrib/pg_tde/pg_tde--1.0-beta2.sql
@@ -607,7 +607,6 @@ AS $$
 BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_key_providers() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_is_encrypted(regclass) TO %I', target_role);
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_principal_key_info() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_global_principal_key_info() TO %I', target_role);
@@ -688,7 +687,6 @@ AS $$
 BEGIN
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_key_providers() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_is_encrypted(regclass) FROM %I', target_role);
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_principal_key_info() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_global_principal_key_info() FROM %I', target_role);

--- a/contrib/pg_tde/pg_tde--1.0-beta2.sql
+++ b/contrib/pg_tde/pg_tde--1.0-beta2.sql
@@ -424,24 +424,10 @@ RETURNS table_am_handler
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_internal_has_key(relation regclass)
+CREATE FUNCTION pg_tde_is_encrypted(relation regclass)
 RETURNS boolean
 LANGUAGE C
 AS 'MODULE_PATHNAME';
-
-CREATE FUNCTION pg_tde_is_encrypted(table_name regclass)
-RETURNS boolean
-LANGUAGE SQL
-BEGIN ATOMIC
-    SELECT EXISTS (
-        SELECT 1
-        FROM   pg_catalog.pg_class
-        WHERE  oid = table_name
-        AND    (relam = (SELECT oid FROM pg_catalog.pg_am WHERE amname = 'tde_heap_basic')
-            OR (relam = (SELECT oid FROM pg_catalog.pg_am WHERE amname = 'tde_heap'))
-                AND pg_tde_internal_has_key(table_name))
-        );
-END;
 
 CREATE FUNCTION pg_tde_set_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS boolean

--- a/contrib/pg_tde/pg_tde--1.0-beta2.sql
+++ b/contrib/pg_tde/pg_tde--1.0-beta2.sql
@@ -424,22 +424,22 @@ RETURNS table_am_handler
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_internal_has_key(oid OID)
+CREATE FUNCTION pg_tde_internal_has_key(relation regclass)
 RETURNS boolean
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_is_encrypted(table_name TEXT)
+CREATE FUNCTION pg_tde_is_encrypted(table_name regclass)
 RETURNS boolean
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT EXISTS (
         SELECT 1
         FROM   pg_catalog.pg_class
-        WHERE  oid = table_name::regclass::oid
+        WHERE  oid = table_name
         AND    (relam = (SELECT oid FROM pg_catalog.pg_am WHERE amname = 'tde_heap_basic')
             OR (relam = (SELECT oid FROM pg_catalog.pg_am WHERE amname = 'tde_heap'))
-                AND pg_tde_internal_has_key(table_name::regclass::oid))
+                AND pg_tde_internal_has_key(table_name))
         );
 END;
 
@@ -621,7 +621,7 @@ AS $$
 BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_key_providers() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_is_encrypted(text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_is_encrypted(regclass) TO %I', target_role);
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_principal_key_info() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_global_principal_key_info() TO %I', target_role);
@@ -702,7 +702,7 @@ AS $$
 BEGIN
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_key_providers() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_is_encrypted(text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_is_encrypted(regclass) FROM %I', target_role);
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_principal_key_info() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_global_principal_key_info() FROM %I', target_role);

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.inc
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.inc
@@ -23,6 +23,12 @@ SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE
 SELECT pg_tde_is_encrypted('test_enc');
 SELECT pg_tde_is_encrypted('test_norm');
 
+SELECT pg_tde_is_encrypted('test_enc_id_seq');
+SELECT pg_tde_is_encrypted('test_norm_id_seq');
+
+SELECT pg_tde_is_encrypted('test_enc_pkey');
+SELECT pg_tde_is_encrypted('test_norm_pkey');
+
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
 

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.inc
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.inc
@@ -23,8 +23,6 @@ SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE
 SELECT pg_tde_is_encrypted('test_enc');
 SELECT pg_tde_is_encrypted('test_norm');
 
-SELECT pg_tde_is_encrypted('public.test_enc');
-
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
 


### PR DESCRIPTION
To support checking other relation types than tables we removed the
    check for the tde_heap access method and just do the following:
    
        relam == 'tde_heap_basic' || GetSMGRRelationKey() != NULL
    
And to simplify the logic we merge pg_tde_is_encrypted() and
    pg_tde_internal_has_key(), which will be an even bigger win once
    the tde_heap_basic access method is removed since then we would
    only need to check if there is a SMGR key.

Additionally we let everyone call the  `pg_tde_is_encrypted()` since it is not security critical or related to principal key management and we change the signature from ``pg_tde_is_encrypted(text)` to `pg_tde_is_encrypted(regclass)` to improve user ergonomics.