### PR TITLE
Remove no longer used field in `TDEPrincipalKeyInfo`

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -357,8 +357,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	new_principal_key = palloc(sizeof(TDEPrincipalKey));
 	new_principal_key->keyInfo.databaseId = dbOid;
 	new_principal_key->keyInfo.keyringId = new_keyring->keyring_id;
-	strncpy(new_principal_key->keyInfo.keyId.name, key_name, TDE_KEY_NAME_LEN);
-	strncpy(new_principal_key->keyInfo.keyId.versioned_name, key_name, TDE_KEY_NAME_LEN);
+	strncpy(new_principal_key->keyInfo.name, key_name, TDE_KEY_NAME_LEN);
 	gettimeofday(&new_principal_key->keyInfo.creationTime, NULL);
 	new_principal_key->keyLength = keyInfo->data.len;
 
@@ -732,7 +731,7 @@ pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid)
 	/* Initialize the values and null flags */
 
 	/* TEXT: Principal key name */
-	values[0] = CStringGetTextDatum(principal_key->keyInfo.keyId.name);
+	values[0] = CStringGetTextDatum(principal_key->keyInfo.name);
 	isnull[0] = false;
 	/* TEXT: Keyring provider name */
 	if (keyring)
@@ -794,7 +793,7 @@ get_principal_key_from_keyring(Oid dbOid, bool pushToCache)
 		return NULL;
 	}
 
-	keyInfo = KeyringGetKey(keyring, principalKeyInfo->keyId.versioned_name, false, &keyring_ret);
+	keyInfo = KeyringGetKey(keyring, principalKeyInfo->name, false, &keyring_ret);
 
 	if (keyInfo == NULL)
 	{
@@ -1014,7 +1013,7 @@ pg_tde_is_provider_used(Oid databaseOid, Oid providerId)
 static bool
 pg_tde_is_same_principal_key(TDEPrincipalKey *a, TDEPrincipalKey *b)
 {
-	return a != NULL && b != NULL && strncmp(a->keyInfo.keyId.name, b->keyInfo.keyId.name, PRINCIPAL_KEY_NAME_LEN) == 0 && a->keyInfo.keyringId == b->keyInfo.keyringId;
+	return a != NULL && b != NULL && strncmp(a->keyInfo.name, b->keyInfo.name, PRINCIPAL_KEY_NAME_LEN) == 0 && a->keyInfo.keyringId == b->keyInfo.keyringId;
 }
 
 static void

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -21,19 +21,13 @@
 
 #define PRINCIPAL_KEY_NAME_LEN TDE_KEY_NAME_LEN
 
-typedef struct TDEPrincipalKeyId
-{
-	char		name[PRINCIPAL_KEY_NAME_LEN];
-	char		versioned_name[PRINCIPAL_KEY_NAME_LEN + 4];
-} TDEPrincipalKeyId;
-
 typedef struct TDEPrincipalKeyInfo
 {
 	Oid			databaseId;
 	Oid			userId;
 	Oid			keyringId;
 	struct timeval creationTime;
-	TDEPrincipalKeyId keyId;
+	char		name[PRINCIPAL_KEY_NAME_LEN];
 } TDEPrincipalKeyInfo;
 
 typedef struct TDEPrincipalKey

--- a/contrib/pg_tde/typedefs.list
+++ b/contrib/pg_tde/typedefs.list
@@ -56,7 +56,6 @@ TDELockTypes
 TDEMapEntry
 TDEMapFilePath
 TDEPrincipalKey
-TDEPrincipalKeyId
 TDEPrincipalKeyInfo
 TDEShmemSetupRoutine
 TdeCreateEvent


### PR DESCRIPTION
The versioned_name field has not been used since commit 150e918ada95f74f8a10b215790e3f826c9b9c93 so to avoid confusing the reader we remove it. As a bonus we save some bytes in the principal key file.

