### PR TITLE
Fixing sequence and alter table handling in the event trigger

### DIFF
--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -15,8 +15,8 @@ SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_name    varchar(32) unique not null,
+     continent        varchar(32) not null
 ) using :tde_am;
  
 INSERT INTO country_table (country_name, continent)
@@ -108,7 +108,14 @@ SELECT pg_tde_is_encrypted('country_table');
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  pg_tde_is_encrypted 
 ---------------------
- f
+ t
+(1 row)
+
+ALTER TABLE country_table ADD y text;
+SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
+ pg_tde_is_encrypted 
+---------------------
+ t
 (1 row)
 
 CREATE TABLE country_table2 (
@@ -122,10 +129,10 @@ CREATE TABLE country_table3 (
      country_name    text unique not null,
      continent        text not null
 ) USING heap;
-psql:sql/change_access_method.inc:63: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:67: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:65: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:69: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 ALTER TABLE country_table2 SET access method  :tde_am;
 CREATE TABLE country_table3 (
      country_id        serial primary key,

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -37,8 +37,20 @@ SELECT pg_tde_is_encrypted('country_table');
  t
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 -- Try changing the encrypted table to an unencrypted table
 ALTER TABLE country_table SET access method  heap;
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 -- Insert some more data 
 INSERT INTO country_table (country_name, continent)
      VALUES ('France', 'Europe'),
@@ -56,6 +68,12 @@ SELECT * FROM country_table;
 (6 rows)
 
 SELECT pg_tde_is_encrypted('country_table');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  pg_tde_is_encrypted 
 ---------------------
  f
@@ -87,6 +105,12 @@ SELECT pg_tde_is_encrypted('country_table');
  t
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 CREATE TABLE country_table2 (
      country_id        serial primary key,
      country_name    text unique not null,
@@ -98,10 +122,10 @@ CREATE TABLE country_table3 (
      country_name    text unique not null,
      continent        text not null
 ) USING heap;
-psql:sql/change_access_method.inc:54: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:63: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:56: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:65: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 ALTER TABLE country_table2 SET access method  :tde_am;
 CREATE TABLE country_table3 (
      country_id        serial primary key,

--- a/contrib/pg_tde/expected/change_access_method_basic.out
+++ b/contrib/pg_tde/expected/change_access_method_basic.out
@@ -15,11 +15,9 @@ SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_name    varchar(32) unique not null,
+     continent        varchar(32) not null
 ) using :tde_am;
-psql:sql/change_access_method.inc:10: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:10: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 psql:sql/change_access_method.inc:10: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 psql:sql/change_access_method.inc:10: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 psql:sql/change_access_method.inc:10: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
@@ -100,8 +98,6 @@ psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, an
 psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 INSERT INTO country_table (country_name, continent)
      VALUES ('China', 'Asia'),
             ('Brazil', 'South America'),
@@ -136,6 +132,15 @@ SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  f
 (1 row)
 
+ALTER TABLE country_table ADD y text;
+psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 CREATE TABLE country_table2 (
      country_id        serial primary key,
      country_name    text unique not null,
@@ -147,21 +152,21 @@ CREATE TABLE country_table3 (
      country_name    text unique not null,
      continent        text not null
 ) USING heap;
-psql:sql/change_access_method.inc:63: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:67: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:65: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:69: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 ALTER TABLE country_table2 SET access method  :tde_am;
-psql:sql/change_access_method.inc:67: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:71: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 CREATE TABLE country_table3 (
      country_id        serial primary key,
      country_name    text unique not null,
      continent        text not null
 ) using :tde_am;
-psql:sql/change_access_method.inc:73: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:77: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 DROP TABLE country_table;
 DROP TABLE country_table2;
 DROP TABLE country_table3;
-psql:sql/change_access_method.inc:77: ERROR:  table "country_table3" does not exist
+psql:sql/change_access_method.inc:81: ERROR:  table "country_table3" does not exist
 SET pg_tde.enforce_encryption = OFF;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/change_access_method_basic.out
+++ b/contrib/pg_tde/expected/change_access_method_basic.out
@@ -46,9 +46,21 @@ SELECT pg_tde_is_encrypted('country_table');
  t
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 -- Try changing the encrypted table to an unencrypted table
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:22: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:24: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 -- Insert some more data 
 INSERT INTO country_table (country_name, continent)
      VALUES ('France', 'Europe'),
@@ -71,28 +83,34 @@ SELECT pg_tde_is_encrypted('country_table');
  f
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 -- Change it back to encrypted
 ALTER TABLE country_table SET access method  :tde_am;
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 INSERT INTO country_table (country_name, continent)
      VALUES ('China', 'Asia'),
             ('Brazil', 'South America'),
             ('Australia', 'Oceania');
-psql:sql/change_access_method.inc:38: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:38: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:38: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:45: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:45: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:45: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 SELECT * FROM country_table;
-psql:sql/change_access_method.inc:39: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
  country_id | country_name |   continent   
 ------------+--------------+---------------
           1 | Japan        | Asia
@@ -112,6 +130,12 @@ SELECT pg_tde_is_encrypted('country_table');
  t
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 CREATE TABLE country_table2 (
      country_id        serial primary key,
      country_name    text unique not null,
@@ -123,21 +147,21 @@ CREATE TABLE country_table3 (
      country_name    text unique not null,
      continent        text not null
 ) USING heap;
-psql:sql/change_access_method.inc:54: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:63: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:56: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:65: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 ALTER TABLE country_table2 SET access method  :tde_am;
-psql:sql/change_access_method.inc:58: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:67: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 CREATE TABLE country_table3 (
      country_id        serial primary key,
      country_name    text unique not null,
      continent        text not null
 ) using :tde_am;
-psql:sql/change_access_method.inc:64: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:73: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 DROP TABLE country_table;
 DROP TABLE country_table2;
 DROP TABLE country_table3;
-psql:sql/change_access_method.inc:68: ERROR:  table "country_table3" does not exist
+psql:sql/change_access_method.inc:77: ERROR:  table "country_table3" does not exist
 SET pg_tde.enforce_encryption = OFF;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/change_access_method.inc
+++ b/contrib/pg_tde/sql/change_access_method.inc
@@ -18,8 +18,13 @@ SELECT * FROM country_table;
 
 SELECT pg_tde_is_encrypted('country_table');
 
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+
 -- Try changing the encrypted table to an unencrypted table
 ALTER TABLE country_table SET access method  heap;
+
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+
 -- Insert some more data 
 INSERT INTO country_table (country_name, continent)
      VALUES ('France', 'Europe'),
@@ -28,6 +33,8 @@ INSERT INTO country_table (country_name, continent)
 
 SELECT * FROM country_table;
 SELECT pg_tde_is_encrypted('country_table');
+
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
 
 -- Change it back to encrypted
 ALTER TABLE country_table SET access method  :tde_am;
@@ -38,6 +45,8 @@ INSERT INTO country_table (country_name, continent)
             ('Australia', 'Oceania');
 SELECT * FROM country_table;
 SELECT pg_tde_is_encrypted('country_table');
+
+SELECT pg_tde_is_encrypted('country_table_country_id_seq');
 
 CREATE TABLE country_table2 (
      country_id        serial primary key,

--- a/contrib/pg_tde/sql/change_access_method.inc
+++ b/contrib/pg_tde/sql/change_access_method.inc
@@ -5,8 +5,8 @@ SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_name    varchar(32) unique not null,
+     continent        varchar(32) not null
 ) using :tde_am;
  
 INSERT INTO country_table (country_name, continent)
@@ -47,6 +47,10 @@ SELECT * FROM country_table;
 SELECT pg_tde_is_encrypted('country_table');
 
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+
+ALTER TABLE country_table ADD y text;
+
+SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
 
 CREATE TABLE country_table2 (
      country_id        serial primary key,

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -26,6 +26,8 @@ typedef struct TdeCreateEvent
 								 * contains InvalidOid */
 	RangeVar   *relation;		/* Reference to the parsed relation from
 								 * create statement */
+	bool		alterSequenceMode;	/* true when alter sequence is executed by
+									 * pg_tde */
 } TdeCreateEvent;
 
 extern TdeCreateEvent *GetCurrentTdeCreateEvent(void);

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -10,16 +10,8 @@
 #include "postgres.h"
 #include "nodes/parsenodes.h"
 
-typedef enum TdeCreateEventType
-{
-	TDE_UNKNOWN_CREATE_EVENT,
-	TDE_TABLE_CREATE_EVENT,
-	TDE_INDEX_CREATE_EVENT
-} TdeCreateEventType;
-
 typedef struct TdeCreateEvent
 {
-	TdeCreateEventType eventType;	/* DDL statement type */
 	bool		encryptMode;	/* true when the table uses encryption */
 	Oid			baseTableOid;	/* Oid of table on which index is being
 								 * created on. For create table statement this

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -230,6 +230,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
 	InternalKey *key;
+	TdeCreateEvent *event = GetCurrentTdeCreateEvent();
 
 	/*
 	 * This is the only function that gets called during actual CREATE
@@ -243,7 +244,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 	 * Later calls then decide to encrypt or not based on the existence of the
 	 * key
 	 */
-	key = tde_smgr_get_key(reln, &relold, true);
+	key = tde_smgr_get_key(reln, event->alterSequenceMode ? NULL : &relold, true);
 
 	if (key)
 	{

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -68,20 +68,14 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 		return key;
 	}
 
-	/* if this is a CREATE TABLE, we have to generate the key */
-	if (event->encryptMode == true && event->eventType == TDE_TABLE_CREATE_EVENT && can_create)
+	/*
+	 * Can be many things, such as: CREATE TABLE ALTER TABLE SET ACCESS METHOD
+	 * ALTER TABLE something else on an encrypted table CREATE INDEX ...
+	 *
+	 * Every file has its own key, that makes logistics easier.
+	 */
+	if (event->encryptMode == true && can_create)
 	{
-		return pg_tde_create_smgr_key(&reln->smgr_rlocator);
-	}
-
-	/* if this is a CREATE INDEX, we have to load the key based on the table */
-	if (event->encryptMode == true && event->eventType == TDE_INDEX_CREATE_EVENT && can_create)
-	{
-		/* For now keep it simple and create separate key for indexes */
-		/*
-		 * Later we might modify the map infrastructure to support the same
-		 * keys
-		 */
 		return pg_tde_create_smgr_key(&reln->smgr_rlocator);
 	}
 


### PR DESCRIPTION
PG-1379 and PG-1378.

This PR contains two commits, as these are related and would conflict otherwise.

With these changes:

* sequences correctly follow the encryption status of the table, even after set access method
* files created during alter table are correctly encrypted, even if the alter doesn't contain a set access method clause