### PR TITLE
Fix validation of KMIP options

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -802,10 +802,10 @@ load_kmip_keyring_provider_options(char *keyring_options)
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("missing in the keyring options:%s%s%s%s",
-						*(kmip_keyring->kmip_host) ? "" : " kmip_host",
-						*(kmip_keyring->kmip_port) ? "" : " kmip_port",
-						*(kmip_keyring->kmip_ca_path) ? "" : " kmip_ca_path",
-						*(kmip_keyring->kmip_cert_path) ? "" : " kmip_cert_path")));
+						*(kmip_keyring->kmip_host) ? "" : " host",
+						*(kmip_keyring->kmip_port) ? "" : " port",
+						*(kmip_keyring->kmip_ca_path) ? "" : " caPath",
+						*(kmip_keyring->kmip_cert_path) ? "" : " certPath")));
 		return NULL;
 	}
 

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -795,13 +795,15 @@ load_kmip_keyring_provider_options(char *keyring_options)
 	}
 
 	if (strlen(kmip_keyring->kmip_host) == 0 ||
+		strlen(kmip_keyring->kmip_port) == 0 ||
 		strlen(kmip_keyring->kmip_ca_path) == 0 ||
 		strlen(kmip_keyring->kmip_cert_path) == 0)
 	{
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("missing in the keyring options:%s%s%s",
+				 errmsg("missing in the keyring options:%s%s%s%s",
 						*(kmip_keyring->kmip_host) ? "" : " kmip_host",
+						*(kmip_keyring->kmip_port) ? "" : " kmip_port",
 						*(kmip_keyring->kmip_ca_path) ? "" : " kmip_ca_path",
 						*(kmip_keyring->kmip_cert_path) ? "" : " kmip_cert_path")));
 		return NULL;


### PR DESCRIPTION
As far as I gather the port is always required so make sure we actually do require it plus fix the error messages.
