### PR TITLE
PG-1373 Have strings as separate allocations for keyrings

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -741,7 +741,7 @@ load_file_keyring_provider_options(char *keyring_options)
 		return NULL;
 	}
 
-	if (strlen(file_keyring->file_name) == 0)
+	if (file_keyring->file_name == NULL || file_keyring->file_name[0] == '\0')
 	{
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -765,16 +765,16 @@ load_vaultV2_keyring_provider_options(char *keyring_options)
 		return NULL;
 	}
 
-	if (strlen(vaultV2_keyring->vault_token) == 0 ||
-		strlen(vaultV2_keyring->vault_url) == 0 ||
-		strlen(vaultV2_keyring->vault_mount_path) == 0)
+	if (vaultV2_keyring->vault_token == NULL || vaultV2_keyring->vault_token[0] == '\0' ||
+		vaultV2_keyring->vault_url == NULL || vaultV2_keyring->vault_url[0] == '\0' ||
+		vaultV2_keyring->vault_mount_path == NULL || vaultV2_keyring->vault_mount_path[0] == '\0')
 	{
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("missing in the keyring options:%s%s%s",
-						*(vaultV2_keyring->vault_token) ? "" : " token",
-						*(vaultV2_keyring->vault_url) ? "" : " url",
-						*(vaultV2_keyring->vault_mount_path) ? "" : " mountPath")));
+						(vaultV2_keyring->vault_token != NULL && vaultV2_keyring->vault_token[0] != '\0') ? "" : " token",
+						(vaultV2_keyring->vault_url != NULL && vaultV2_keyring->vault_url[0] != '\0') ? "" : " url",
+						(vaultV2_keyring->vault_mount_path != NULL && vaultV2_keyring->vault_mount_path[0] != '\0') ? "" : " mountPath")));
 		return NULL;
 	}
 
@@ -802,10 +802,10 @@ load_kmip_keyring_provider_options(char *keyring_options)
 		ereport(WARNING,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("missing in the keyring options:%s%s%s%s",
-						*(kmip_keyring->kmip_host) ? "" : " host",
-						*(kmip_keyring->kmip_port) ? "" : " port",
-						*(kmip_keyring->kmip_ca_path) ? "" : " caPath",
-						*(kmip_keyring->kmip_cert_path) ? "" : " certPath")));
+						(kmip_keyring->kmip_host != NULL && kmip_keyring->kmip_host[0] != '\0') ? "" : " host",
+						(kmip_keyring->kmip_port != NULL && kmip_keyring->kmip_port[0] != '\0') ? "" : " port",
+						(kmip_keyring->kmip_ca_path != NULL && kmip_keyring->kmip_ca_path[0] != '\0') ? "" : " caPath",
+						(kmip_keyring->kmip_cert_path != NULL && kmip_keyring->kmip_cert_path[0] != '\0') ? "" : " certPath")));
 		return NULL;
 	}
 

--- a/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
@@ -434,33 +434,33 @@ json_kring_assign_scalar(JsonKeyringState *parse, JsonKeyringField field, char *
 			break;
 
 		case JF_FILE_PATH:
-			strncpy(file->file_name, value, sizeof(file->file_name));
+			file->file_name = value;
 			break;
 
 		case JK_VAULT_TOKEN:
-			strncpy(vault->vault_token, value, sizeof(vault->vault_token));
+			vault->vault_token = value;
 			break;
 		case JK_VAULT_URL:
-			strncpy(vault->vault_url, value, sizeof(vault->vault_url));
+			vault->vault_url = value;
 			break;
 		case JK_VAULT_MOUNT_PATH:
-			strncpy(vault->vault_mount_path, value, sizeof(vault->vault_mount_path));
+			vault->vault_mount_path = value;
 			break;
 		case JK_VAULT_CA_PATH:
-			strncpy(vault->vault_ca_path, value, sizeof(vault->vault_ca_path));
+			vault->vault_ca_path = value;
 			break;
 
 		case JK_KMIP_HOST:
-			strncpy(kmip->kmip_host, value, sizeof(kmip->kmip_host));
+			kmip->kmip_host = value;
 			break;
 		case JK_KMIP_PORT:
-			strncpy(kmip->kmip_port, value, sizeof(kmip->kmip_port));
+			kmip->kmip_port = value;
 			break;
 		case JK_KMIP_CA_PATH:
-			strncpy(kmip->kmip_ca_path, value, sizeof(kmip->kmip_ca_path));
+			kmip->kmip_ca_path = value;
 			break;
 		case JK_KMIP_CERT_PATH:
-			strncpy(kmip->kmip_cert_path, value, sizeof(kmip->kmip_cert_path));
+			kmip->kmip_cert_path = value;
 			break;
 
 		default:

--- a/contrib/pg_tde/src/include/catalog/keyring_min.h
+++ b/contrib/pg_tde/src/include/catalog/keyring_min.h
@@ -10,7 +10,6 @@ typedef unsigned int Oid;
 
 #define MAX_PROVIDER_NAME_LEN 128	/* pg_tde_key_provider's provider_name
 									 * size */
-#define MAX_VAULT_V2_KEY_LEN 128	/* From hashi corp docs */
 #define MAX_KEYRING_OPTION_LEN 1024
 typedef enum ProviderType
 {
@@ -75,25 +74,25 @@ typedef struct TDEKeyringRoutine
 typedef struct FileKeyring
 {
 	GenericKeyring keyring;		/* Must be the first field */
-	char		file_name[MAXPGPATH];
+	char	   *file_name;
 } FileKeyring;
 
 typedef struct VaultV2Keyring
 {
 	GenericKeyring keyring;		/* Must be the first field */
-	char		vault_token[MAX_VAULT_V2_KEY_LEN];
-	char		vault_url[MAXPGPATH];
-	char		vault_ca_path[MAXPGPATH];
-	char		vault_mount_path[MAXPGPATH];
+	char	   *vault_token;
+	char	   *vault_url;
+	char	   *vault_ca_path;
+	char	   *vault_mount_path;
 } VaultV2Keyring;
 
 typedef struct KmipKeyring
 {
 	GenericKeyring keyring;		/* Must be the first field */
-	char		kmip_host[MAXPGPATH];
-	char		kmip_port[32];
-	char		kmip_ca_path[MAXPGPATH];
-	char		kmip_cert_path[MAXPGPATH];
+	char	   *kmip_host;
+	char	   *kmip_port;
+	char	   *kmip_ca_path;
+	char	   *kmip_cert_path;
 } KmipKeyring;
 
 #endif


### PR DESCRIPTION
While not allowing the strings to be NULL simplified validation slightly it made other parts of the code more complex and introduced a security issue in the form of the 'strncpy()`  uses. And while we could have fixed the security issue this code is cleaner.
