### PR TITLE
Rename typedefs keyInfo and keyData to fix indentation

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -273,7 +273,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	LWLock	   *lock_files = tde_lwlock_enc_keys();
 	bool		already_has_key = false;
 	GenericKeyring *new_keyring;
-	const keyInfo *keyInfo = NULL;
+	const KeyInfo *keyInfo = NULL;
 	bool		success = true;
 
 	if (AllowInheritGlobalProviders == false && providerOid != dbOid)
@@ -316,6 +316,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 	{
 		KeyringReturnCodes kr_ret;
+
 		keyInfo = KeyringGetKey(new_keyring, key_name, false, &kr_ret);
 
 		if (kr_ret != KEYRING_CODE_SUCCESS && kr_ret != KEYRING_CODE_RESOURCE_NOT_AVAILABLE)
@@ -327,7 +328,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 		}
 	}
 
-	if (keyInfo !=NULL && ensure_new_key)
+	if (keyInfo != NULL && ensure_new_key)
 	{
 		LWLockRelease(lock_files);
 
@@ -781,7 +782,7 @@ get_principal_key_from_keyring(Oid dbOid, bool pushToCache)
 	GenericKeyring *keyring;
 	TDEPrincipalKey *principalKey = NULL;
 	TDEPrincipalKeyInfo *principalKeyInfo = NULL;
-	const keyInfo *keyInfo = NULL;
+	const KeyInfo *keyInfo = NULL;
 	KeyringReturnCodes keyring_ret;
 
 	Assert(LWLockHeldByMeInMode(tde_lwlock_enc_keys(), LW_EXCLUSIVE));

--- a/contrib/pg_tde/src/include/catalog/keyring_min.h
+++ b/contrib/pg_tde/src/include/catalog/keyring_min.h
@@ -23,17 +23,17 @@ typedef enum ProviderType
 #define MAX_KEY_DATA_SIZE 32	/* maximum 256 bit encryption */
 #define INTERNAL_KEY_LEN 16
 
-typedef struct keyData
+typedef struct KeyData
 {
 	unsigned char data[MAX_KEY_DATA_SIZE];
 	unsigned	len;
-} keyData;
+} KeyData;
 
-typedef struct keyInfo
+typedef struct KeyInfo
 {
 	char		name[TDE_KEY_NAME_LEN];
-	keyData		data;
-} keyInfo;
+	KeyData		data;
+} KeyInfo;
 
 typedef enum KeyringReturnCodes
 {
@@ -59,8 +59,8 @@ typedef struct GenericKeyring
 
 typedef struct TDEKeyringRoutine
 {
-	keyInfo    *(*keyring_get_key) (GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *returnCode);
-	KeyringReturnCodes (*keyring_store_key) (GenericKeyring *keyring, keyInfo *key, bool throw_error);
+	KeyInfo    *(*keyring_get_key) (GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *returnCode);
+	KeyringReturnCodes (*keyring_store_key) (GenericKeyring *keyring, KeyInfo *key, bool throw_error);
 } TDEKeyringRoutine;
 
 /*

--- a/contrib/pg_tde/src/include/keyring/keyring_api.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_api.h
@@ -14,9 +14,9 @@
 
 extern bool RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type);
 
-extern KeyringReturnCodes KeyringStoreKey(GenericKeyring *keyring, keyInfo *key, bool throw_error);
-extern keyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *returnCode);
-extern keyInfo *KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len, bool throw_error);
-extern keyInfo *KeyringGenerateNewKey(const char *key_name, unsigned key_len);
+extern KeyringReturnCodes KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key, bool throw_error);
+extern KeyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *returnCode);
+extern KeyInfo *KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len, bool throw_error);
+extern KeyInfo *KeyringGenerateNewKey(const char *key_name, unsigned key_len);
 
 #endif							/* KEYRING_API_H */

--- a/contrib/pg_tde/src/keyring/keyring_api.c
+++ b/contrib/pg_tde/src/keyring/keyring_api.c
@@ -101,7 +101,7 @@ RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type)
 	return true;
 }
 
-keyInfo *
+KeyInfo *
 KeyringGetKey(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *returnCode)
 {
 	KeyProviders *kp = find_key_provider(keyring->type);
@@ -118,7 +118,7 @@ KeyringGetKey(GenericKeyring *keyring, const char *key_name, bool throw_error, K
 }
 
 KeyringReturnCodes
-KeyringStoreKey(GenericKeyring *keyring, keyInfo *key, bool throw_error)
+KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key, bool throw_error)
 {
 	KeyProviders *kp = find_key_provider(keyring->type);
 	int			ereport_level = throw_error ? ERROR : WARNING;
@@ -132,14 +132,14 @@ KeyringStoreKey(GenericKeyring *keyring, keyInfo *key, bool throw_error)
 	return kp->routine->keyring_store_key(keyring, key, throw_error);
 }
 
-keyInfo *
+KeyInfo *
 KeyringGenerateNewKey(const char *key_name, unsigned key_len)
 {
-	keyInfo    *key;
+	KeyInfo    *key;
 
 	Assert(key_len <= 32);
 	/* Struct will be saved to disk so keep clean */
-	key = palloc0(sizeof(keyInfo));
+	key = palloc0(sizeof(KeyInfo));
 	key->data.len = key_len;
 	if (!RAND_bytes(key->data.data, key_len))
 	{
@@ -150,10 +150,10 @@ KeyringGenerateNewKey(const char *key_name, unsigned key_len)
 	return key;
 }
 
-keyInfo *
+KeyInfo *
 KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len, bool throw_error)
 {
-	keyInfo    *key = KeyringGenerateNewKey(key_name, key_len);
+	KeyInfo    *key = KeyringGenerateNewKey(key_name, key_len);
 	int			ereport_level = throw_error ? ERROR : WARNING;
 
 	if (key == NULL)

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -29,8 +29,8 @@
 
 extern bool RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type);
 
-static KeyringReturnCodes set_key_by_name(GenericKeyring *keyring, keyInfo *key, bool throw_error);
-static keyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *return_code);
+static KeyringReturnCodes set_key_by_name(GenericKeyring *keyring, KeyInfo *key, bool throw_error);
+static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *return_code);
 
 const TDEKeyringRoutine keyringKmipRoutine = {
 	.keyring_get_key = get_key_by_name,
@@ -100,7 +100,7 @@ kmipSslConnect(KmipCtx *ctx, KmipKeyring *kmip_keyring, bool throw_error)
 }
 
 static KeyringReturnCodes
-set_key_by_name(GenericKeyring *keyring, keyInfo *key, bool throw_error)
+set_key_by_name(GenericKeyring *keyring, KeyInfo *key, bool throw_error)
 {
 	KmipCtx		ctx;
 	KmipKeyring *kmip_keyring = (KmipKeyring *) keyring;
@@ -163,10 +163,10 @@ void	   *palloc(size_t);
 
 void		pfree(void *);
 
-static keyInfo *
+static KeyInfo *
 get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *return_code)
 {
-	keyInfo    *key = NULL;
+	KeyInfo    *key = NULL;
 	KmipKeyring *kmip_keyring = (KmipKeyring *) keyring;
 	char	   *id = 0;
 	KmipCtx		ctx;
@@ -237,7 +237,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error,
 
 	/* 2. get key */
 
-	key = palloc(sizeof(keyInfo));
+	key = palloc(sizeof(KeyInfo));
 
 	{
 		char	   *keyp = NULL;

--- a/contrib/pg_tde/typedefs.list
+++ b/contrib/pg_tde/typedefs.list
@@ -24,6 +24,8 @@ JsonKeyringState
 JsonVaultRespField
 JsonVaultRespSemState
 JsonVaultRespState
+Keydata
+KeyInfo
 KeyProviders
 KeyringProvideRecord
 KeyringProviderXLRecord
@@ -70,8 +72,6 @@ XLogPrincipalKeyRotate
 XLogRelKey
 itemIdCompactData
 itemIdCompactData
-keyData
-keyInfo
 xl_multi_insert_tuple
 xl_multi_insert_tuple
 xl_tdeheap_confirm

--- a/src/backend/access/gist/gistscan.c
+++ b/src/backend/access/gist/gistscan.c
@@ -251,7 +251,7 @@ gistrescan(IndexScanDesc scan, ScanKey key, int nkeys,
 
 		for (i = 0; i < scan->numberOfKeys; i++)
 		{
-			ScanKey		skey = scan->keyData +i;
+			ScanKey		skey = scan->keyData + i;
 
 			/*
 			 * Copy consistent support function to ScanKey structure instead

--- a/src/backend/access/index/genam.c
+++ b/src/backend/access/index/genam.c
@@ -143,7 +143,7 @@ RelationGetIndexScan(Relation indexRelation, int nkeys, int norderbys)
 void
 IndexScanEnd(IndexScanDesc scan)
 {
-	if (scan->keyData !=NULL)
+	if (scan->keyData != NULL)
 		pfree(scan->keyData);
 	if (scan->orderByData != NULL)
 		pfree(scan->orderByData);

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -433,7 +433,7 @@ btendscan(IndexScanDesc scan)
 	/* No need to invalidate positions, the RAM is about to be freed. */
 
 	/* Release storage */
-	if (so->keyData !=NULL)
+	if (so->keyData != NULL)
 		pfree(so->keyData);
 	/* so->arrayKeys and so->orderProcs are in arrayContext */
 	if (so->arrayContext != NULL)

--- a/src/backend/access/nbtree/nbtutils.c
+++ b/src/backend/access/nbtree/nbtutils.c
@@ -566,7 +566,7 @@ _bt_preprocess_array_keys_final(IndexScanDesc scan, int *keyDataMap)
 
 	for (int output_ikey = 0; output_ikey < so->numberOfKeys; output_ikey++)
 	{
-		ScanKey		outkey = so->keyData +output_ikey;
+		ScanKey		outkey = so->keyData + output_ikey;
 		int			input_ikey;
 		bool		found PG_USED_FOR_ASSERTS_ONLY = false;
 
@@ -1471,7 +1471,7 @@ _bt_rewind_nonrequired_arrays(IndexScanDesc scan, ScanDirection dir)
 
 	for (int ikey = 0; ikey < so->numberOfKeys; ikey++)
 	{
-		ScanKey		cur = so->keyData +ikey;
+		ScanKey		cur = so->keyData + ikey;
 		BTArrayKeyInfo *array = NULL;
 		int			first_elem_dir;
 
@@ -1557,7 +1557,7 @@ _bt_tuple_before_array_skeys(IndexScanDesc scan, ScanDirection dir,
 
 	for (int ikey = sktrig; ikey < so->numberOfKeys; ikey++)
 	{
-		ScanKey		cur = so->keyData +ikey;
+		ScanKey		cur = so->keyData + ikey;
 		Datum		tupdatum;
 		bool		tupnull;
 		int32		result;
@@ -1837,7 +1837,7 @@ _bt_advance_array_keys(IndexScanDesc scan, BTReadPageState *pstate,
 
 	for (int ikey = 0; ikey < so->numberOfKeys; ikey++)
 	{
-		ScanKey		cur = so->keyData +ikey;
+		ScanKey		cur = so->keyData + ikey;
 		BTArrayKeyInfo *array = NULL;
 		Datum		tupdatum;
 		bool		required = false,
@@ -3010,7 +3010,7 @@ _bt_verify_arrays_bt_first(IndexScanDesc scan, ScanDirection dir)
 
 	for (int ikey = 0; ikey < so->numberOfKeys; ikey++)
 	{
-		ScanKey		cur = so->keyData +ikey;
+		ScanKey		cur = so->keyData + ikey;
 		BTArrayKeyInfo *array = NULL;
 		int			first_elem_dir;
 
@@ -3052,7 +3052,7 @@ _bt_verify_keys_with_arraykeys(IndexScanDesc scan)
 
 	for (int ikey = 0; ikey < so->numberOfKeys; ikey++)
 	{
-		ScanKey		cur = so->keyData +ikey;
+		ScanKey		cur = so->keyData + ikey;
 		BTArrayKeyInfo *array;
 
 		if (cur->sk_strategy != BTEqualStrategyNumber ||
@@ -3690,7 +3690,7 @@ _bt_check_compare(IndexScanDesc scan, ScanDirection dir,
 
 	for (; *ikey < so->numberOfKeys; (*ikey)++)
 	{
-		ScanKey		key = so->keyData +*ikey;
+		ScanKey		key = so->keyData + *ikey;
 		Datum		datum;
 		bool		isNull;
 		bool		requiredSameDir = false,

--- a/src/backend/utils/adt/jsonb_gin.c
+++ b/src/backend/utils/adt/jsonb_gin.c
@@ -292,7 +292,6 @@ jsonb_ops__add_path_item(JsonPathGinPath *path, JsonPathItem *jsp)
 				char	   *key = jspGetString(jsp, &len);
 
 				keyName = make_text_key(JGINFLAG_KEY, key, len);
-
 				break;
 			}
 
@@ -301,7 +300,6 @@ jsonb_ops__add_path_item(JsonPathGinPath *path, JsonPathItem *jsp)
 		case jpiAnyArray:
 		case jpiIndexArray:
 			keyName = PointerGetDatum(NULL);
-
 			break;
 
 		default:
@@ -313,7 +311,6 @@ jsonb_ops__add_path_item(JsonPathGinPath *path, JsonPathItem *jsp)
 
 	pentry->type = jsp->type;
 	pentry->keyName = keyName;
-
 	pentry->parent = path->items;
 
 	path->items = pentry;

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -1042,7 +1042,7 @@ typedef struct BTScanOpaqueData
 	/* these fields are set by _bt_preprocess_keys(): */
 	bool		qual_ok;		/* false if qual can never be satisfied */
 	int			numberOfKeys;	/* number of preprocessed scan keys */
-	ScanKey keyData;			/* array of preprocessed scan keys */
+	ScanKey		keyData;		/* array of preprocessed scan keys */
 
 	/* workspace for SK_SEARCHARRAY support */
 	int			numArrayKeys;	/* number of equality-type array keys */

--- a/src/include/access/spgist_private.h
+++ b/src/include/access/spgist_private.h
@@ -199,7 +199,7 @@ typedef struct SpGistScanOpaqueData
 
 	/* Index quals to be passed to opclass (null-related quals removed) */
 	int			numberOfKeys;	/* number of index qualifier conditions */
-	ScanKey keyData;			/* array of index qualifier descriptors */
+	ScanKey		keyData;		/* array of index qualifier descriptors */
 	int			numberOfOrderBys;	/* number of ordering operators */
 	int			numberOfNonNullOrderBys;	/* number of ordering operators
 											 * with non-NULL arguments */


### PR DESCRIPTION
The collision of variable and field names vs typedefs caused various weird indentation issues so we rename the two typedefs to avoid these collisions. This also reduces the diff between our stuff and the upstream.
