### PR TITLE
Simplify check for if heap AM related extensions can be used

### DIFF
--- a/contrib/amcheck/verify_heapam.c
+++ b/contrib/amcheck/verify_heapam.c
@@ -305,7 +305,7 @@ verify_heapam(PG_FUNCTION_ARGS)
 	 * Other relkinds might be using a different AM, so check.
 	 */
 	if (ctx.rel->rd_rel->relkind != RELKIND_SEQUENCE &&
-		ctx.rel->rd_rel->relam != HEAP_TABLE_AM_OID && ctx.rel->rd_rel->relam != get_tde_table_am_oid())
+		ctx.rel->rd_tableam != GetHeapamTableAmRoutine())
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("only heap AM is supported")));

--- a/contrib/pageinspect/heapfuncs.c
+++ b/contrib/pageinspect/heapfuncs.c
@@ -325,7 +325,7 @@ tuple_data_split_internal(Oid relid, char *tupdata,
 	 * Sequences always use heap AM, but they don't show that in the catalogs.
 	 */
 	if (rel->rd_rel->relkind != RELKIND_SEQUENCE &&
-		rel->rd_rel->relam != HEAP_TABLE_AM_OID && rel->rd_rel->relam != get_tde_table_am_oid())
+		rel->rd_tableam != GetHeapamTableAmRoutine())
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("only heap AM is supported")));
 

--- a/contrib/pg_surgery/heap_surgery.c
+++ b/contrib/pg_surgery/heap_surgery.c
@@ -112,7 +112,7 @@ heap_force_common(FunctionCallInfo fcinfo, HeapTupleForceOption heap_force_opt)
 						RelationGetRelationName(rel)),
 				 errdetail_relkind_not_supported(rel->rd_rel->relkind)));
 
-	if (rel->rd_rel->relam != HEAP_TABLE_AM_OID && rel->rd_rel->relam != get_tde_table_am_oid())
+	if (rel->rd_tableam != GetHeapamTableAmRoutine())
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("only heap AM is supported")));

--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -23,7 +23,7 @@
 #include "access/genam.h"
 #include "access/heapam.h"
 
-Oid
+static Oid
 get_tde_basic_table_am_oid(void)
 {
 	return get_table_am_oid("tde_heap_basic", false);

--- a/contrib/pg_tde/src/include/common/pg_tde_utils.h
+++ b/contrib/pg_tde/src/include/common/pg_tde_utils.h
@@ -13,7 +13,6 @@
 #ifndef FRONTEND
 #include "nodes/pg_list.h"
 
-extern Oid	get_tde_basic_table_am_oid(void);
 extern List *get_all_tde_tables(void);
 extern int	get_tde_tables_count(void);
 #endif							/* !FRONTEND */

--- a/contrib/pg_tde/src/include/common/pg_tde_utils.h
+++ b/contrib/pg_tde/src/include/common/pg_tde_utils.h
@@ -14,7 +14,6 @@
 #include "nodes/pg_list.h"
 
 extern Oid	get_tde_basic_table_am_oid(void);
-extern Oid	get_tde_table_am_oid(void);
 extern List *get_all_tde_tables(void);
 extern int	get_tde_tables_count(void);
 #endif							/* !FRONTEND */

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -15,6 +15,7 @@
 #include "utils/rel.h"
 #include "utils/builtins.h"
 #include "catalog/pg_class.h"
+#include "commands/defrem.h"
 #include "access/table.h"
 #include "access/relation.h"
 #include "catalog/pg_event_trigger.h"
@@ -38,6 +39,7 @@ int			event_trigger_level = 0;
 
 
 static void reset_current_tde_create_event(void);
+static Oid	get_tde_table_am_oid(void);
 
 PG_FUNCTION_INFO_V1(pg_tde_ddl_command_start_capture);
 PG_FUNCTION_INFO_V1(pg_tde_ddl_command_end_capture);
@@ -293,4 +295,10 @@ reset_current_tde_create_event(void)
 	tdeCurrentCreateEvent.baseTableOid = InvalidOid;
 	tdeCurrentCreateEvent.relation = NULL;
 	alterSetAccessMethod = false;
+}
+
+static Oid
+get_tde_table_am_oid(void)
+{
+	return get_table_am_oid("tde_heap", false);
 }

--- a/contrib/pgrowlocks/pgrowlocks.c
+++ b/contrib/pgrowlocks/pgrowlocks.c
@@ -92,7 +92,7 @@ pgrowlocks(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a table",
 						RelationGetRelationName(rel))));
-	else if (rel->rd_rel->relam != HEAP_TABLE_AM_OID && rel->rd_rel->relam != get_tde_table_am_oid())
+	else if (rel->rd_tableam != GetHeapamTableAmRoutine())
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("only heap AM is supported")));

--- a/contrib/pgstattuple/pgstatapprox.c
+++ b/contrib/pgstattuple/pgstatapprox.c
@@ -293,7 +293,7 @@ pgstattuple_approx_internal(Oid relid, FunctionCallInfo fcinfo)
 						RelationGetRelationName(rel)),
 				 errdetail_relkind_not_supported(rel->rd_rel->relkind)));
 
-	if (rel->rd_rel->relam != HEAP_TABLE_AM_OID && rel->rd_rel->relam != get_tde_table_am_oid())
+	if (rel->rd_tableam != GetHeapamTableAmRoutine())
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("only heap AM is supported")));
 

--- a/contrib/pgstattuple/pgstattuple.c
+++ b/contrib/pgstattuple/pgstattuple.c
@@ -327,7 +327,7 @@ pgstat_heap(Relation rel, FunctionCallInfo fcinfo)
 	 * Sequences always use heap AM, but they don't show that in the catalogs.
 	 */
 	if (rel->rd_rel->relkind != RELKIND_SEQUENCE &&
-		rel->rd_rel->relam != HEAP_TABLE_AM_OID && rel->rd_rel->relam != get_tde_table_am_oid())
+		rel->rd_tableam != GetHeapamTableAmRoutine())
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("only heap AM is supported")));

--- a/src/backend/access/table/tableam.c
+++ b/src/backend/access/table/tableam.c
@@ -757,10 +757,3 @@ table_block_relation_estimate_size(Relation rel, int32 *attr_widths,
 	else
 		*allvisfrac = (double) relallvisible / curpages;
 }
-
-
-Oid
-get_tde_table_am_oid(void)
-{
-	return get_table_am_oid("tde_heap", false);
-}

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -2107,6 +2107,4 @@ extern const TableAmRoutine *GetTableAmRoutine(Oid amhandler);
 
 extern const TableAmRoutine *GetHeapamTableAmRoutine(void);
 
-extern Oid	get_tde_table_am_oid(void);
-
 #endif							/* TABLEAM_H */


### PR DESCRIPTION
Instead of checking for the oid of the AM we check for if the
    access method of the relation uses the routine struct as the
    heap does. This allows the tools to be support all access
    methods which are simple copies of heap.

I am uncertain if this is something which the project would be
    interested in but it decreases the size of our diff against
    upstream.
